### PR TITLE
Add Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,6 @@ being installed in the system:
 
 - `rsync`
 - `ssh`
-- `nc`
-
-Resin Sync **doesn't support Windows yet**, however it will work
-under Cygwin.
 
 You can save all the options mentioned below in a `resin-sync.yml`
 file, by using the same option names as keys. For example:
@@ -47,7 +43,6 @@ file, by using the same option names as keys. For example:
 	$ cat $PWD/resin-sync.yml
 	source: src/
 	before: 'echo Hello'
-	exec: 'python main.py'
 	ignore:
 		- .git
 		- node_modules/
@@ -67,9 +62,8 @@ set in the configuration file.
 | [options.source] | <code>String</code> | <code>$PWD</code> | source path |
 | [options.ignore] | <code>Array.&lt;String&gt;</code> |  | ignore paths |
 | [options.before] | <code>String</code> |  | command to execute before sync |
-| [options.exec] | <code>String</code> |  | command to execute after sync (on the device) |
 | [options.progress] | <code>Boolean</code> | <code>true</code> | display sync progress |
-| [options.port] | <code>Number</code> | <code>80</code> | ssh port |
+| [options.port] | <code>Number</code> | <code>22</code> | ssh port |
 
 **Example**  
 ```js
@@ -78,6 +72,14 @@ resinSync.sync('7a4e3dc', {
   progress: false
 });
 ```
+
+Windows
+-------
+
+1. Install [MinGW](http://www.mingw.org).
+2. Install the `msys-rsync` and `msys-openssh` packages.
+3. Add MinGW to the `%PATH%` if this hasn't been done by the installer already. The location where the binaries are places is usually `C:\MinGW\msys\1.0\bin`, but it can vary if you selected a different location in the installer.
+4. Copy your SSH keys to `%homedrive%%homepath\.ssh`.
 
 Support
 -------

--- a/build/rsync.js
+++ b/build/rsync.js
@@ -42,7 +42,6 @@ ssh = require('./ssh');
  * @param {String} options.username - username
  * @param {String} options.uuid - device uuid
  * @param {String} options.containerId - container id
- * @param {String} options.source - source path
  * @param {Boolean} [options.progress] - show progress
  * @param {String|String[]} [options.ignore] - pattern/s to ignore
  * @param {Number} [options.port=22] - ssh port
@@ -53,8 +52,7 @@ ssh = require('./ssh');
  * command = rsync.getCommand
  *		username: 'test',
  *		uuid: '1324'
- *		containerId: '6789',
- * 	source: 'foo/bar'
+ *		containerId: '6789'
  */
 
 exports.getCommand = function(options) {
@@ -91,15 +89,6 @@ exports.getCommand = function(options) {
           required: 'Missing containerId'
         }
       },
-      source: {
-        description: 'source',
-        type: 'string',
-        required: true,
-        messages: {
-          type: 'Not a string: source',
-          required: 'Missing source'
-        }
-      },
       progress: {
         description: 'progress',
         type: 'boolean',
@@ -112,12 +101,9 @@ exports.getCommand = function(options) {
       }
     }
   });
-  if (!_.str.isBlank(options.source) && _.last(options.source) !== '/') {
-    options.source += '/';
-  }
   username = options.username, uuid = options.uuid, containerId = options.containerId, port = options.port;
   args = {
-    source: options.source,
+    source: '.',
     destination: "" + username + "@ssh." + (settings.get('proxyUrl')) + ":",
     progress: options.progress,
     shell: ssh.getConnectCommand({
@@ -128,9 +114,6 @@ exports.getCommand = function(options) {
     }),
     flags: 'az'
   };
-  if (_.isEmpty(options.source.trim())) {
-    args.source = '.';
-  }
   if (options.ignore != null) {
     args.exclude = options.ignore;
   }

--- a/build/sync.js
+++ b/build/sync.js
@@ -54,9 +54,6 @@ config = require('./config');
  * - `rsync`
  * - `ssh`
  *
- * Resin Sync **doesn't support Windows yet**, however it will work
- * under Cygwin.
- *
  * You can save all the options mentioned below in a `resin-sync.yml`
  * file, by using the same option names as keys. For example:
  *
@@ -118,7 +115,9 @@ exports.sync = function(uuid, options) {
     }
     return Promise["try"](function() {
       if (options.before != null) {
-        return shell.runCommand(options.before);
+        return shell.runCommand(options.before, {
+          cwd: options.source
+        });
       }
     });
   }).then(function() {
@@ -146,7 +145,9 @@ exports.sync = function(uuid, options) {
         containerId: containerId
       });
       command = rsync.getCommand(options);
-      return shell.runCommand(command).then(function() {
+      return shell.runCommand(command, {
+        cwd: options.source
+      }).then(function() {
         spinner.stop();
         console.log("Synced /usr/src/app on " + (uuid.substring(0, 7)) + ".");
         spinner = new Spinner('Starting application container...');

--- a/doc/README.hbs
+++ b/doc/README.hbs
@@ -34,6 +34,14 @@ Documentation
 {{>members~}}
 {{/module}}
 
+Windows
+-------
+
+1. Install [MinGW](http://www.mingw.org).
+2. Install the `msys-rsync` and `msys-openssh` packages.
+3. Add MinGW to the `%PATH%` if this hasn't been done by the installer already. The location where the binaries are places is usually `C:\MinGW\msys\1.0\bin`, but it can vary if you selected a different location in the installer.
+4. Copy your SSH keys to `%homedrive%%homepath\.ssh`.
+
 Support
 -------
 

--- a/lib/rsync.coffee
+++ b/lib/rsync.coffee
@@ -32,7 +32,6 @@ ssh = require('./ssh')
 # @param {String} options.username - username
 # @param {String} options.uuid - device uuid
 # @param {String} options.containerId - container id
-# @param {String} options.source - source path
 # @param {Boolean} [options.progress] - show progress
 # @param {String|String[]} [options.ignore] - pattern/s to ignore
 # @param {Number} [options.port=22] - ssh port
@@ -43,8 +42,7 @@ ssh = require('./ssh')
 # command = rsync.getCommand
 #		username: 'test',
 #		uuid: '1324'
-#		containerId: '6789',
-# 	source: 'foo/bar'
+#		containerId: '6789'
 ###
 exports.getCommand = (options = {}) ->
 
@@ -71,13 +69,6 @@ exports.getCommand = (options = {}) ->
 				messages:
 					type: 'Not a string: containerId'
 					required: 'Missing containerId'
-			source:
-				description: 'source'
-				type: 'string'
-				required: true
-				messages:
-					type: 'Not a string: source'
-					required: 'Missing source'
 			progress:
 				description: 'progress'
 				type: 'boolean'
@@ -87,14 +78,9 @@ exports.getCommand = (options = {}) ->
 				type: [ 'string', 'array' ]
 				message: 'Not a string or array: ignore'
 
-	# A trailing slash on the source avoids creating
-	# an additional directory level at the destination.
-	if not _.str.isBlank(options.source) and _.last(options.source) isnt '/'
-		options.source += '/'
-
 	{ username, uuid, containerId, port } = options
 	args =
-		source: options.source
+		source: '.'
 		destination: "#{username}@ssh.#{settings.get('proxyUrl')}:"
 		progress: options.progress
 		shell: ssh.getConnectCommand({ username, uuid, containerId, port })
@@ -105,9 +91,6 @@ exports.getCommand = (options = {}) ->
 		#
 		# z = compress during transfer
 		flags: 'az'
-
-	if _.isEmpty(options.source.trim())
-		args.source = '.'
 
 	# For some reason, adding `exclude: undefined` adds an `--exclude`
 	# with nothing in it right before the source, which makes rsync

--- a/lib/shell.coffee
+++ b/lib/shell.coffee
@@ -15,6 +15,7 @@ limitations under the License.
 ###
 
 child_process = require('child_process')
+_ = require('lodash')
 os = require('os')
 rindle = require('rindle')
 
@@ -30,12 +31,10 @@ rindle = require('rindle')
 # subShellCommand = shell.getSubShellCommand('foo')
 ###
 exports.getSubShellCommand = (command) ->
-
-	# Assume Cygwin
 	if os.platform() is 'win32'
 		return {
-			program: 'sh'
-			args: [ '-c', command ]
+			program: 'cmd.exe'
+			args: [ '/s', '/c', command ]
 		}
 	else
 		return {
@@ -52,16 +51,39 @@ exports.getSubShellCommand = (command) ->
 # stdin is inherited from the parent process.
 #
 # @param {String} command - command
+# @param {Object} [options] - options
+# @param {String} [options.cwd] - current working directory
 # @returns {Promise}
 #
 # @example
 # shell.runCommand('echo hello').then ->
 # 	console.log('Done!')
 ###
-exports.runCommand = (command) ->
+exports.runCommand = (command, options = {}) ->
+	env = {}
+
+	if os.platform() is 'win32'
+
+		# Under Windows, openssh attempts to read SSH keys from
+		# `/home/<username>`, however this makes no sense in Windows.
+		# As a workaround, we can set the %HOME% environment variable
+		# to `/<home drive letter>/Users/<user>` to trick openssh
+		# to read ssh keys from `<home drive letter>:\Users\<user>\.ssh`
+		homedrive = _.get(process, 'env.homedrive', 'C:').slice(0, 1).toLowerCase()
+		homepath = _.get(process, 'env.homepath', '').replace(/\\/g, '/')
+		env.HOME = "/#{homedrive}#{homepath}"
+
 	subShellCommand = exports.getSubShellCommand(command)
 	spawn = child_process.spawn subShellCommand.program, subShellCommand.args,
 		stdio: 'inherit'
+		env: _.merge(env, process.env)
+		cwd: options.cwd
+
+		# This is an internal undocumented option that causes
+		# spawn to execute multiple word commands correctly
+		# on Windows when passing them to `cmd.exe`
+		# See https://github.com/nodejs/node-v0.x-archive/issues/2318#issuecomment-3220048
+		windowsVerbatimArguments: true
 
 	return rindle.wait(spawn).spread (code) ->
 		return if code is 0

--- a/lib/sync.coffee
+++ b/lib/sync.coffee
@@ -42,9 +42,6 @@ config = require('./config')
 # - `rsync`
 # - `ssh`
 #
-# Resin Sync **doesn't support Windows yet**, however it will work
-# under Cygwin.
-#
 # You can save all the options mentioned below in a `resin-sync.yml`
 # file, by using the same option names as keys. For example:
 #
@@ -100,7 +97,7 @@ exports.sync = (uuid, options) ->
 	resin.models.device.isOnline(uuid).tap (isOnline) ->
 		throw new Error('Device is not online') if not isOnline
 		Promise.try ->
-			shell.runCommand(options.before) if options.before?
+			shell.runCommand(options.before, cwd: options.source) if options.before?
 	.then ->
 		Promise.props
 			uuid: resin.models.device.get(uuid).get('uuid')	# get full uuid
@@ -122,7 +119,7 @@ exports.sync = (uuid, options) ->
 
 			options = _.merge(options, { username, uuid, containerId })
 			command = rsync.getCommand(options)
-			shell.runCommand(command)
+			shell.runCommand(command, cwd: options.source)
 			.then ->
 				spinner.stop()
 				console.log("Synced /usr/src/app on #{uuid.substring(0,7)}.")

--- a/tests/rsync.spec.coffee
+++ b/tests/rsync.spec.coffee
@@ -17,25 +17,11 @@ assertCommand = (command, options) ->
 			return "--exclude=#{pattern}"
 		.join(' ')
 
-	if os.platform() is 'win32' and options.source isnt '.'
-		expected += " \"#{options.source}\""
-	else
-		expected += " #{options.source}"
-
-	expected += " #{options.username}@ssh.resindevice.io:"
+	expected += " . #{options.username}@ssh.resindevice.io:"
 
 	m.chai.expect(command).to.equal(expected)
 
 describe 'Rsync:', ->
-
-	it 'should throw if source is not a string', ->
-		m.chai.expect ->
-			rsync.getCommand
-				username: 'test'
-				uuid: '1234'
-				containerId: '4567'
-				source: [ 'foo', 'bar' ]
-		.to.throw('Not a string: source')
 
 	it 'should throw if progress is not a boolean', ->
 		m.chai.expect ->
@@ -43,7 +29,6 @@ describe 'Rsync:', ->
 				username: 'test'
 				uuid: '1234'
 				containerId: '4567'
-				source: 'foo/bar'
 				progress: 'true'
 		.to.throw('Not a boolean: progress')
 
@@ -53,62 +38,20 @@ describe 'Rsync:', ->
 				username: 'test'
 				uuid: '1234'
 				containerId: '4567'
-				source: 'foo/bar'
 				ignore: 1234
 		.to.throw('Not a string or array: ignore')
-
-	it 'should interpret an source containing only blank spaces as .', ->
-		command = rsync.getCommand
-			username: 'test'
-			uuid: '1234'
-			containerId: '4567'
-			source: '      '
-
-		assertCommand command,
-			username: 'test'
-			uuid: '1234'
-			containerId: '4567'
-			source: '.'
-
-	it 'should automatically append a slash at the end of source', ->
-		command = rsync.getCommand
-			username: 'test'
-			uuid: '1234'
-			containerId: '4567'
-			source: 'foo'
-
-		assertCommand command,
-			username: 'test'
-			uuid: '1234'
-			containerId: '4567'
-			source: "foo#{path.sep}"
-
-	it 'should not append a slash at the end of source is there is one already', ->
-		command = rsync.getCommand
-			username: 'test'
-			uuid: '1234'
-			containerId: '4567'
-			source: "foo#{path.sep}"
-
-		assertCommand command,
-			username: 'test'
-			uuid: '1234'
-			containerId: '4567'
-			source: "foo#{path.sep}"
 
 	it 'should be able to set progress to true', ->
 		command = rsync.getCommand
 			username: 'test'
 			uuid: '1234'
 			containerId: '4567'
-			source: "foo#{path.sep}bar#{path.sep}"
 			progress: true
 
 		assertCommand command,
 			username: 'test'
 			uuid: '1234'
 			containerId: '4567'
-			source: "foo#{path.sep}bar#{path.sep}"
 			progress: true
 
 	it 'should be able to set progress to false', ->
@@ -116,28 +59,24 @@ describe 'Rsync:', ->
 			username: 'test'
 			uuid: '1234'
 			containerId: '4567'
-			source: "foo#{path.sep}bar#{path.sep}"
 			progress: false
 
 		assertCommand command,
 			username: 'test'
 			uuid: '1234'
 			containerId: '4567'
-			source: "foo#{path.sep}bar#{path.sep}"
 
 	it 'should be able to exclute a single pattern', ->
 		command = rsync.getCommand
 			username: 'test'
 			uuid: '1234'
 			containerId: '4567'
-			source: "foo#{path.sep}bar#{path.sep}"
 			ignore: '.git'
 
 		assertCommand command,
 			username: 'test'
 			uuid: '1234'
 			containerId: '4567'
-			source: "foo#{path.sep}bar#{path.sep}"
 			exclude: [ '.git' ]
 
 	it 'should be able to exclute a multiple patterns', ->
@@ -145,12 +84,10 @@ describe 'Rsync:', ->
 			username: 'test'
 			uuid: '1234'
 			containerId: '4567'
-			source: "foo#{path.sep}bar#{path.sep}"
 			ignore: [ '.git', 'node_modules' ]
 
 		assertCommand command,
 			username: 'test'
 			uuid: '1234'
 			containerId: '4567'
-			source: "foo#{path.sep}bar#{path.sep}"
 			exclude: [ '.git', 'node_modules' ]

--- a/tests/shell.spec.coffee
+++ b/tests/shell.spec.coffee
@@ -17,17 +17,13 @@ describe 'Shell:', ->
 			afterEach ->
 				@osPlatformStub.restore()
 
-			it 'should set program to sh', ->
+			it 'should set program to cmd.exe', ->
 				subshell = shell.getSubShellCommand('foo')
-				m.chai.expect(subshell.program).to.equal('sh')
+				m.chai.expect(subshell.program).to.equal('cmd.exe')
 
 			it 'should set the correct sh arguments', ->
 				subshell = shell.getSubShellCommand('foo')
-				m.chai.expect(subshell.args).to.deep.equal([ '-c', 'foo' ])
-
-			it 'should surround a multiple word command in double quotes', ->
-				subshell = shell.getSubShellCommand('foo bar baz')
-				m.chai.expect(subshell.args).to.deep.equal([ '-c', 'foo bar baz' ])
+				m.chai.expect(subshell.args).to.deep.equal([ '/s', '/c', 'foo' ])
 
 		describe 'given not windows', ->
 
@@ -117,8 +113,8 @@ describe 'Shell:', ->
 				it 'should call spawn with the correct arguments', ->
 					shell.runCommand('echo foo')
 					args = @childProcessSpawnStub.firstCall.args
-					m.chai.expect(args[0]).to.equal('sh')
-					m.chai.expect(args[1]).to.deep.equal([ '-c', 'echo foo' ])
+					m.chai.expect(args[0]).to.equal('cmd.exe')
+					m.chai.expect(args[1]).to.deep.equal([ '/s', '/c', 'echo foo' ])
 
 			describe 'given not windows', ->
 


### PR DESCRIPTION
The following fixes were implemented for `resin-sync` to support Windows
(through `cmd.exe`, not Cygwin):
- Execute shell processes with `cmd.exe`.
- Set the `%HOME%` environment variable to make `openssh` read ssh keys
  from the correct location.
- Lock `rsync` source to `.` and execute command in the corresponding
  source directory since colons confuse `rsync` when passing absolute
  paths containing a drive letter.

Signed-off-by: Juan Cruz Viotti jviottidc@gmail.com
