### PR TITLE
resin sync improvements

### DIFF
--- a/build/config.js
+++ b/build/config.js
@@ -30,14 +30,19 @@ jsYaml = require('js-yaml');
  * @function
  * @private
  *
+ * @param {String} baseDir
+ *
  * @returns {String} config path
  *
  * @example
- * configPath = config.getPath()
+ * configPath = config.getPath('.')
  */
 
-exports.getPath = function() {
-  return path.join(process.cwd(), 'resin-sync.yml');
+exports.getPath = function(baseDir) {
+  if (baseDir == null) {
+    baseDir = process.cwd();
+  }
+  return path.join(baseDir, '.resin-sync.yml');
 };
 
 
@@ -49,15 +54,17 @@ exports.getPath = function() {
  * @description
  * If no configuration file is found, return an empty object.
  *
+ * @param {String} baseDir
+ *
  * @returns {Object} configuration
  *
  * @example
- * options = config.load()
+ * options = config.load('.')
  */
 
-exports.load = function() {
+exports.load = function(baseDir) {
   var config, configPath, error, result;
-  configPath = exports.getPath();
+  configPath = exports.getPath(baseDir);
   try {
     config = fs.readFileSync(configPath, {
       encoding: 'utf8'
@@ -74,4 +81,38 @@ exports.load = function() {
     throw new Error("Invalid configuration file: " + configPath);
   }
   return result;
+};
+
+
+/**
+ * @summary Serialezed object as yaml object and saves it to file
+ * @function
+ * @protected
+ *
+ * @param {String} yamlObj
+ * @param {String} baseDir
+ *
+ * @throws Exception on error
+ * @example
+ * options = config.save(yamlObj, '.')
+ */
+
+exports.save = function(yamlObj, baseDir) {
+  var configSavePath, error, yamlDump;
+  if (yamlObj == null) {
+    yamlObj = {};
+  }
+  configSavePath = exports.getPath(baseDir);
+  try {
+    yamlDump = jsYaml.safeDump(yamlObj);
+    return fs.writeFileSync(configSavePath, yamlDump, {
+      encoding: 'utf8'
+    });
+  } catch (_error) {
+    error = _error;
+    if (error.code === 'ENOENT') {
+      return {};
+    }
+    throw error;
+  }
 };

--- a/build/ssh.js
+++ b/build/ssh.js
@@ -93,6 +93,6 @@ exports.getConnectCommand = function(options) {
   });
   username = options.username, uuid = options.uuid, containerId = options.containerId, port = options.port;
   verbose = options.verbose ? '-vv ' : '';
-  result = "ssh " + verbose + "-p " + port + " -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null " + username + "@ssh." + (settings.get('proxyUrl')) + " rsync " + uuid + " " + containerId;
+  result = "ssh " + verbose + "-p " + port + " -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ControlMaster=no " + username + "@ssh." + (settings.get('proxyUrl')) + " rsync " + uuid + " " + containerId;
   return result;
 };

--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -18,13 +18,13 @@ gulp.task 'coffee', ->
 		.pipe(coffee(bare: true)).on('error', gutil.log)
 		.pipe(gulp.dest('build/'))
 
-gulp.task 'test', ->
+gulp.task 'test', ['lint'], ->
 	gulp.src(OPTIONS.files.tests, read: false)
 		.pipe(mocha({
 			reporter: 'min'
 		}))
 
-gulp.task 'lint', ->
+gulp.task 'lint', ['coffee'], ->
 	gulp.src(OPTIONS.files.coffee)
 		.pipe(coffeelint({
 			optFile: OPTIONS.config.coffeelint

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -24,13 +24,15 @@ jsYaml = require('js-yaml')
 # @function
 # @private
 #
+# @param {String} baseDir
+#
 # @returns {String} config path
 #
 # @example
-# configPath = config.getPath()
+# configPath = config.getPath('.')
 ###
-exports.getPath = ->
-	return path.join(process.cwd(), 'resin-sync.yml')
+exports.getPath = (baseDir = process.cwd()) ->
+	return path.join(baseDir, '.resin-sync.yml')
 
 ###*
 # @summary Load configuration file
@@ -40,13 +42,15 @@ exports.getPath = ->
 # @description
 # If no configuration file is found, return an empty object.
 #
+# @param {String} baseDir
+#
 # @returns {Object} configuration
 #
 # @example
-# options = config.load()
+# options = config.load('.')
 ###
-exports.load = ->
-	configPath = exports.getPath()
+exports.load = (baseDir) ->
+	configPath = exports.getPath(baseDir)
 
 	try
 		config = fs.readFileSync(configPath, encoding: 'utf8')
@@ -60,3 +64,26 @@ exports.load = ->
 		throw new Error("Invalid configuration file: #{configPath}")
 
 	return result
+#
+###*
+# @summary Serialezed object as yaml object and saves it to file
+# @function
+# @protected
+#
+# @param {String} yamlObj
+# @param {String} baseDir
+#
+# @throws Exception on error
+# @example
+# options = config.save(yamlObj, '.')
+###
+exports.save = (yamlObj = {}, baseDir) ->
+	configSavePath = exports.getPath(baseDir)
+
+	try
+		yamlDump = jsYaml.safeDump(yamlObj)
+		fs.writeFileSync(configSavePath, yamlDump, encoding: 'utf8')
+	catch error
+		if error.code is 'ENOENT'
+			return {}
+		throw error

--- a/lib/rsync.coffee
+++ b/lib/rsync.coffee
@@ -30,6 +30,7 @@ ssh = require('./ssh')
 # @param {String} options.username - username
 # @param {String} options.uuid - device uuid
 # @param {String} options.containerId - container id
+# @param {String} options.destination - destination directory on device
 # @param {Boolean} [options.progress] - show progress
 # @param {String|String[]} [options.ignore] - pattern/s to ignore
 # @param {Number} [options.port=22] - ssh port
@@ -65,11 +66,16 @@ exports.getCommand = (options = {}) ->
 				description: 'verbose'
 				type: 'boolean'
 				message: 'Not a boolean: verbose'
+			destination:
+				description: 'destination'
+				type: 'any'
+				required: true
+				message: 'Not a string: destination'
 
 	{ username } = options
 	args =
 		source: '.'
-		destination: "#{username}@ssh.#{settings.get('proxyUrl')}:"
+		destination: "#{username}@ssh.#{settings.get('proxyUrl')}:#{options.destination}"
 		progress: options.progress
 		shell: ssh.getConnectCommand(options)
 

--- a/lib/ssh.coffee
+++ b/lib/ssh.coffee
@@ -83,6 +83,7 @@ exports.getConnectCommand = (options = {}) ->
 		-o LogLevel=ERROR \
 		-o StrictHostKeyChecking=no \
 		-o UserKnownHostsFile=/dev/null \
+		-o ControlMaster=no \
 		#{username}@ssh.#{settings.get('proxyUrl')} \
 		rsync #{uuid} #{containerId}
 	"""

--- a/lib/sync.coffee
+++ b/lib/sync.coffee
@@ -95,8 +95,9 @@ exports.ensureHostOSCompatibility = ensureHostOSCompatibility = Promise.method (
 # @param {String} uuid - device uuid
 # @param {Object} [options] - options
 # @param {String[]} [options.source] - source directory on local host
-# @param {String[]} [options.destination] - destination directory on device
+# @param {String[]} [options.destination=/usr/src/app] - destination directory on device
 # @param {String[]} [options.ignore] - ignore paths
+# @param {String[]} [options.skip-gitignore] - skip .gitignore when parsing exclude/include files
 # @param {String} [options.before] - command to execute before sync
 # @param {Boolean} [options.progress] - display rsync progress
 # @param {Number} [options.port=22] - ssh port

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "bluebird": "^2.10.1",
     "chalk": "^1.1.3",
     "js-yaml": "^3.4.2",
-    "lodash": "^3.10.1",
+    "lodash": "^4.13.1",
     "resin-cli-visuals": "^1.2.8",
     "resin-sdk": "^5.1.0",
     "resin-settings-client": "^3.5.0",

--- a/tests/config.spec.coffee
+++ b/tests/config.spec.coffee
@@ -5,30 +5,30 @@ config = require('../lib/config')
 
 describe 'Config:', ->
 
-	describe '.getPath()', ->
+	describe '.getPath(baseDir)', ->
 
 		it 'should be an absolute path', ->
-			configPath = config.getPath()
+			configPath = config.getPath('/tmp')
 			isAbsolute = configPath is path.resolve(configPath)
 			m.chai.expect(isAbsolute).to.be.true
 
 		it 'should point to a yaml file', ->
-			configPath = config.getPath()
+			configPath = config.getPath('/tmp')
 			m.chai.expect(path.extname(configPath)).to.equal('.yml')
 
-	describe '.load()', ->
+	describe '.load(baseDir)', ->
 
 		describe 'given the file contains valid yaml', ->
 
 			it 'should return the parsed contents', ->
 				filesystem = {}
-				filesystem[config.getPath()] = '''
+				filesystem[config.getPath('/tmp')] = '''
 					source: 'src/'
 					before: 'echo Hello'
 				'''
 				mockFs(filesystem)
 
-				options = config.load()
+				options = config.load('/tmp')
 				m.chai.expect(options).to.deep.equal
 					source: 'src/'
 					before: 'echo Hello'
@@ -39,12 +39,12 @@ describe 'Config:', ->
 
 			it 'should return the parsed contents', ->
 				filesystem = {}
-				filesystem[config.getPath()] = '''
+				filesystem[config.getPath('/tmp')] = '''
 					1234
 				'''
 				mockFs(filesystem)
 
-				m.chai.expect(config.load).to.throw('Invalid configuration file')
+				m.chai.expect(-> config.load('/tmp')).to.throw("Invalid configuration file: #{config.getPath('/tmp')}")
 
 				mockFs.restore()
 
@@ -53,7 +53,7 @@ describe 'Config:', ->
 			it 'should return an empty object', ->
 				mockFs({})
 
-				options = config.load()
+				options = config.load('/tmp')
 				m.chai.expect(options).to.deep.equal({})
 
 				mockFs.restore()

--- a/tests/rsync.spec.coffee
+++ b/tests/rsync.spec.coffee
@@ -1,8 +1,20 @@
 m = require('mochainon')
 _ = require('lodash')
+fs = require('fs')
 path = require('path')
 os = require('os')
 rsync = require('../lib/rsync')
+mockFs = require('mock-fs')
+
+filesystem = {}
+filesystem['/.gitignore'] = '''
+	npm-debug.log
+	node_modules/
+	lib/*
+	!lib/include\\ me.txt
+	# comment
+	\\#notacomment
+'''
 
 assertCommand = (command, options) ->
 	expected = 'rsync -az'
@@ -11,9 +23,10 @@ assertCommand = (command, options) ->
 		expected += ' --progress'
 
 	expected += ' --rsh=\"ssh -p 22 -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null test@ssh.resindevice.io rsync 1234 4567\" --delete'
+	expected += ' --include=\"lib/include\\ me.txt\" --exclude=npm-debug.log --exclude=node_modules/ --exclude=lib/* --exclude=#notacomment'
 
-	if options.exclude?
-		expected += ' ' + _.map options.exclude, (pattern) ->
+	if options.ignore?
+		expected += ' ' + _.map options.ignore, (pattern) ->
 			return "--exclude=#{pattern}"
 		.join(' ')
 
@@ -23,81 +36,45 @@ assertCommand = (command, options) ->
 
 describe 'Rsync:', ->
 
+	defaultOpts =
+		username: 'test'
+		uuid: '1234'
+		source: '/'
+		destination: '/usr/src/app/'
+		containerId: '4567'
+
+	beforeEach ->
+		mockFs(filesystem)
+
+	afterEach ->
+		mockFs.restore()
+
 	it 'should throw if progress is not a boolean', ->
 		m.chai.expect ->
-			rsync.getCommand
-				username: 'test'
-				uuid: '1234'
-				destination: '/usr/src/app/'
-				containerId: '4567'
-				progress: 'true'
+			rsync.getCommand(_.merge({}, defaultOpts, progress: 'true'))
 		.to.throw('Not a boolean: progress')
 
 	it 'should throw if ignore is not a string nor array', ->
 		m.chai.expect ->
-			rsync.getCommand
-				username: 'test'
-				uuid: '1234'
-				destination: '/usr/src/app/'
-				containerId: '4567'
-				ignore: 1234
+			rsync.getCommand(_.merge({}, defaultOpts, ignore: 1234))
 		.to.throw('Not a string or array: ignore')
 
 	it 'should be able to set progress to true', ->
-		command = rsync.getCommand
-			username: 'test'
-			uuid: '1234'
-			destination: '/usr/src/app/'
-			containerId: '4567'
-			progress: true
-
-		assertCommand command,
-			username: 'test'
-			uuid: '1234'
-			destination: '/usr/src/app/'
-			containerId: '4567'
-			progress: true
+		opts = _.merge({}, defaultOpts, progress: true)
+		command = rsync.getCommand(opts)
+		assertCommand(command, opts)
 
 	it 'should be able to set progress to false', ->
-		command = rsync.getCommand
-			username: 'test'
-			uuid: '1234'
-			destination: '/usr/src/app/'
-			containerId: '4567'
-			progress: false
-
-		assertCommand command,
-			username: 'test'
-			uuid: '1234'
-			destination: '/usr/src/app/'
-			containerId: '4567'
+		opts = _.merge({}, defaultOpts, progress: false)
+		command = rsync.getCommand(opts)
+		assertCommand(command, opts)
 
 	it 'should be able to exclute a single pattern', ->
-		command = rsync.getCommand
-			username: 'test'
-			uuid: '1234'
-			destination: '/usr/src/app/'
-			containerId: '4567'
-			ignore: '.git'
-
-		assertCommand command,
-			username: 'test'
-			uuid: '1234'
-			destination: '/usr/src/app/'
-			containerId: '4567'
-			exclude: [ '.git' ]
+		opts = _.merge({}, defaultOpts, ignore: [ '.git' ])
+		command = rsync.getCommand(opts)
+		assertCommand(command, opts)
 
 	it 'should be able to exclute a multiple patterns', ->
-		command = rsync.getCommand
-			username: 'test'
-			uuid: '1234'
-			destination: '/usr/src/app/'
-			containerId: '4567'
-			ignore: [ '.git', 'node_modules' ]
-
-		assertCommand command,
-			username: 'test'
-			uuid: '1234'
-			destination: '/usr/src/app/'
-			containerId: '4567'
-			exclude: [ '.git', 'node_modules' ]
+		opts = _.merge({}, defaultOpts, ignore: [ '.git', 'node_modules' ])
+		command = rsync.getCommand(opts)
+		assertCommand(command, opts)

--- a/tests/rsync.spec.coffee
+++ b/tests/rsync.spec.coffee
@@ -22,7 +22,8 @@ assertCommand = (command, options) ->
 	if options.progress
 		expected += ' --progress'
 
-	expected += ' --rsh=\"ssh -p 22 -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null test@ssh.resindevice.io rsync 1234 4567\" --delete'
+	expected += ' --rsh=\"ssh -p 22 -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ControlMaster=no test@ssh.resindevice.io rsync 1234 4567\"'
+	expected += ' --delete'
 	expected += ' --include=\"lib/include\\ me.txt\" --exclude=npm-debug.log --exclude=node_modules/ --exclude=lib/* --exclude=#notacomment'
 
 	if options.ignore?

--- a/tests/rsync.spec.coffee
+++ b/tests/rsync.spec.coffee
@@ -17,7 +17,7 @@ assertCommand = (command, options) ->
 			return "--exclude=#{pattern}"
 		.join(' ')
 
-	expected += " . #{options.username}@ssh.resindevice.io:"
+	expected += " . #{options.username}@ssh.resindevice.io:/usr/src/app/"
 
 	m.chai.expect(command).to.equal(expected)
 
@@ -28,6 +28,7 @@ describe 'Rsync:', ->
 			rsync.getCommand
 				username: 'test'
 				uuid: '1234'
+				destination: '/usr/src/app/'
 				containerId: '4567'
 				progress: 'true'
 		.to.throw('Not a boolean: progress')
@@ -37,6 +38,7 @@ describe 'Rsync:', ->
 			rsync.getCommand
 				username: 'test'
 				uuid: '1234'
+				destination: '/usr/src/app/'
 				containerId: '4567'
 				ignore: 1234
 		.to.throw('Not a string or array: ignore')
@@ -45,12 +47,14 @@ describe 'Rsync:', ->
 		command = rsync.getCommand
 			username: 'test'
 			uuid: '1234'
+			destination: '/usr/src/app/'
 			containerId: '4567'
 			progress: true
 
 		assertCommand command,
 			username: 'test'
 			uuid: '1234'
+			destination: '/usr/src/app/'
 			containerId: '4567'
 			progress: true
 
@@ -58,24 +62,28 @@ describe 'Rsync:', ->
 		command = rsync.getCommand
 			username: 'test'
 			uuid: '1234'
+			destination: '/usr/src/app/'
 			containerId: '4567'
 			progress: false
 
 		assertCommand command,
 			username: 'test'
 			uuid: '1234'
+			destination: '/usr/src/app/'
 			containerId: '4567'
 
 	it 'should be able to exclute a single pattern', ->
 		command = rsync.getCommand
 			username: 'test'
 			uuid: '1234'
+			destination: '/usr/src/app/'
 			containerId: '4567'
 			ignore: '.git'
 
 		assertCommand command,
 			username: 'test'
 			uuid: '1234'
+			destination: '/usr/src/app/'
 			containerId: '4567'
 			exclude: [ '.git' ]
 
@@ -83,11 +91,13 @@ describe 'Rsync:', ->
 		command = rsync.getCommand
 			username: 'test'
 			uuid: '1234'
+			destination: '/usr/src/app/'
 			containerId: '4567'
 			ignore: [ '.git', 'node_modules' ]
 
 		assertCommand command,
 			username: 'test'
 			uuid: '1234'
+			destination: '/usr/src/app/'
 			containerId: '4567'
 			exclude: [ '.git', 'node_modules' ]

--- a/tests/ssh.spec.coffee
+++ b/tests/ssh.spec.coffee
@@ -21,4 +21,4 @@ describe 'SSH:', ->
 					port: 8080
 					verbose: true
 
-				m.chai.expect(command).to.equal('ssh -vv -p 8080 -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null test@ssh.resindevice.io rsync 1234 4567')
+				m.chai.expect(command).to.equal('ssh -vv -p 8080 -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ControlMaster=no test@ssh.resindevice.io rsync 1234 4567')


### PR DESCRIPTION
## New features
- **Parse .gitignore** for file inclusions/exclusions from resin sync by default (don't parse with `--skip-gitignore`)
- **Automatically save options** to `${source}/.resin-sync.yml` after every run
- Support **user-specified destination directories** with `--destination/-d` option
## Changes
- `resin sync` **`--source/-s`** option is mandatory if a `.resin-sync.yml` file is not found in the current directory
- `resin sync` now only accepts `uuid` as a destination (`appName` has been deprecated)
## Improvements
- Major code refactoring - readability/maintainability increased by 20
- Improve error reporting
## Fixes
- Disable ControlMaster ssh option (as reported in support)
