### PR TITLE
Fix escape characters

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,12 +41,13 @@
     "chalk": "^1.1.3",
     "js-yaml": "^3.4.2",
     "lodash": "^4.13.1",
+    "resin-cli-form": "^1.4.1",
     "resin-cli-visuals": "^1.2.8",
     "resin-sdk": "^5.1.0",
     "resin-settings-client": "^3.5.0",
     "revalidator": "^0.3.1",
     "rindle": "^1.3.0",
-    "rsync": "^0.4.0",
+    "rsync": "0.4.0",
     "semver": "^5.1.0",
     "underscore.string": "^3.2.3"
   }


### PR DESCRIPTION
- Install missing resin-cli-form dependency
- Lock node-rsync version to 0.4.0
- Fix space escape bug in .gitignore
- Add more thorough special character escaping tests
