### PR TITLE
Permit resin sync to device owners only and fail with descriptive message otherwise

### DIFF
--- a/build/sync.js
+++ b/build/sync.js
@@ -242,6 +242,12 @@ exports.sync = function(uuid, cliOptions) {
       }
       return resin.models.device.get(uuid);
     }).tap(function(device) {
+      return resin.auth.getUserId().then(function(userId) {
+        if (userId !== device.user.__id) {
+          throw new Error('Resin sync is permitted to the device owner only. The device owner is the user who provisioned it.');
+        }
+      });
+    }).tap(function(device) {
       return ensureHostOSCompatibility(device.os_version, MIN_HOSTOS_RSYNC);
     }).then(function(device) {
       return Promise.props({

--- a/lib/sync.coffee
+++ b/lib/sync.coffee
@@ -217,6 +217,11 @@ exports.sync = (uuid, cliOptions) ->
 			throw new Error('Device is not online') if not isOnline
 			resin.models.device.get(uuid)
 		.tap (device) ->
+			# Ensure user is the owner of the device. This is also checked on the backend side.
+			resin.auth.getUserId().then (userId) ->
+				if userId isnt device.user.__id
+					throw new Error('Resin sync is permitted to the device owner only. The device owner is the user who provisioned it.')
+		.tap (device) ->
 			ensureHostOSCompatibility(device.os_version, MIN_HOSTOS_RSYNC)
 		.then (device) ->
 			Promise.props


### PR DESCRIPTION
Closes #37 

Application collaborators that will attempt a resin sync on a device that they do not own (i.e. they have not provisioned) will get this error message on `resin sync`:

```
kostasl@macbook:~/resin/github/lekkas/zagori$ resinstaging sync
? Select a device weathered-field (0e3ab5c)
Getting information for device: 0e3ab5c5ed243ee8605fd5ec39324196465d93a13c32eba3597afb0f33be3f
resin sync failed. Error: Resin sync is permitted to the device owner only. The device owner is the user who provisioned it.
kostasl@macbook:~/resin/github/lekkas/zagori$ 
```

cc @jviotti @shaunmulligan 
