### PR TITLE
Convert older, compatible versions of resin-sync.yml to .resin-sync.yml if the latter is not found in the project directory

### DIFF
--- a/build/config.js
+++ b/build/config.js
@@ -38,11 +38,14 @@ jsYaml = require('js-yaml');
  * configPath = config.getPath('.')
  */
 
-exports.getPath = function(baseDir) {
+exports.getPath = function(baseDir, configFile) {
   if (baseDir == null) {
     baseDir = process.cwd();
   }
-  return path.join(baseDir, '.resin-sync.yml');
+  if (configFile == null) {
+    configFile = '.resin-sync.yml';
+  }
+  return path.join(baseDir, configFile);
 };
 
 
@@ -62,14 +65,20 @@ exports.getPath = function(baseDir) {
  * options = config.load('.')
  */
 
-exports.load = function(baseDir) {
+exports.load = function(baseDir, configFile) {
   var config, configPath, error, result;
-  configPath = exports.getPath(baseDir);
+  if (configFile == null) {
+    configFile = '.resin-sync.yml';
+  }
+  configPath = exports.getPath(baseDir, configFile);
   try {
     config = fs.readFileSync(configPath, {
       encoding: 'utf8'
     });
     result = jsYaml.safeLoad(config);
+    if (!_.isPlainObject(result)) {
+      throw new Error("Invalid configuration file: " + configPath);
+    }
   } catch (_error) {
     error = _error;
     if (error.code === 'ENOENT') {
@@ -77,15 +86,12 @@ exports.load = function(baseDir) {
     }
     throw error;
   }
-  if (!_.isPlainObject(result)) {
-    throw new Error("Invalid configuration file: " + configPath);
-  }
   return result;
 };
 
 
 /**
- * @summary Serialezed object as yaml object and saves it to file
+ * @summary Serializes object as yaml object and saves it to file
  * @function
  * @protected
  *
@@ -97,12 +103,15 @@ exports.load = function(baseDir) {
  * options = config.save(yamlObj, '.')
  */
 
-exports.save = function(yamlObj, baseDir) {
+exports.save = function(yamlObj, baseDir, configFile) {
   var configSavePath, error, yamlDump;
   if (yamlObj == null) {
     yamlObj = {};
   }
-  configSavePath = exports.getPath(baseDir);
+  if (configFile == null) {
+    configFile = '.resin-sync.yml';
+  }
+  configSavePath = exports.getPath(baseDir, configFile);
   try {
     yamlDump = jsYaml.safeDump(yamlObj);
     return fs.writeFileSync(configSavePath, yamlDump, {

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -31,8 +31,8 @@ jsYaml = require('js-yaml')
 # @example
 # configPath = config.getPath('.')
 ###
-exports.getPath = (baseDir = process.cwd()) ->
-	return path.join(baseDir, '.resin-sync.yml')
+exports.getPath = (baseDir = process.cwd(), configFile = '.resin-sync.yml') ->
+	return path.join(baseDir, configFile)
 
 ###*
 # @summary Load configuration file
@@ -49,24 +49,24 @@ exports.getPath = (baseDir = process.cwd()) ->
 # @example
 # options = config.load('.')
 ###
-exports.load = (baseDir) ->
-	configPath = exports.getPath(baseDir)
+exports.load = (baseDir, configFile = '.resin-sync.yml') ->
+	configPath = exports.getPath(baseDir, configFile)
 
 	try
 		config = fs.readFileSync(configPath, encoding: 'utf8')
 		result = jsYaml.safeLoad(config)
+
+		if not _.isPlainObject(result)
+			throw new Error("Invalid configuration file: #{configPath}")
 	catch error
 		if error.code is 'ENOENT'
 			return {}
 		throw error
 
-	if not _.isPlainObject(result)
-		throw new Error("Invalid configuration file: #{configPath}")
-
 	return result
 #
 ###*
-# @summary Serialezed object as yaml object and saves it to file
+# @summary Serializes object as yaml object and saves it to file
 # @function
 # @protected
 #
@@ -77,8 +77,8 @@ exports.load = (baseDir) ->
 # @example
 # options = config.save(yamlObj, '.')
 ###
-exports.save = (yamlObj = {}, baseDir) ->
-	configSavePath = exports.getPath(baseDir)
+exports.save = (yamlObj = {}, baseDir, configFile = '.resin-sync.yml') ->
+	configSavePath = exports.getPath(baseDir, configFile)
 
 	try
 		yamlDump = jsYaml.safeDump(yamlObj)


### PR DESCRIPTION
Closes #40 

If no `.resin-sync.yml`  is found in the project folder but a `resin-sync.yml` YAML file exists this message will appear to the user:

``` bash
? A 'resin-sync.yml' configuration file was found, but the current resin-cli version expects a '.resin-sync.yml' file instead.
Convert 'resin-sync.yml' to '.resin-sync.yml' (the original file will be kept either way) ? (Use arrow keys)
❯ Yes 
  No 
```
