### PR TITLE
Integrate resin cli capitano frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 resin-sync
 ==========
 
-> Watch a local project directory and sync it on the fly
+> Update your application from a local source directory to a device on-the-fly.
 
 [![npm version](https://badge.fury.io/js/resin-sync.svg)](http://badge.fury.io/js/resin-sync)
 [![dependencies](https://david-dm.org/resin-io-modules/resin-sync.svg)](https://david-dm.org/resin-io-modules/resin-sync.svg)
@@ -11,7 +11,7 @@ resin-sync
 Role
 ----
 
-The intention of this module is to provide a low level mechanism to sync code to devices.
+The intention of this module is to provide a way to sync changes from a local source directory to a device.
 
 **THIS MODULE IS LOW LEVEL AND IS NOT MEANT TO BE USED BY END USERS DIRECTLY**.
 
@@ -24,62 +24,57 @@ Install `resin-sync` by running:
 $ npm install --save resin-sync
 ```
 
-Documentation
--------------
+Dependencies
+------------
 
-<a name="module_resinSync.sync"></a>
-
-### resinSync.sync(uuid, [options])
-This module provides a way to sync changes from a local source
-directory to a device. It relies on the following dependencies
+`resin sync` relies on the following dependencies
 being installed in the system:
 
 - `rsync`
 - `ssh`
 
-You can save all the options mentioned below in a `resin-sync.yml`
-file, by using the same option names as keys. For example:
-
-	$ cat $PWD/resin-sync.yml
-	source: src/
-	before: 'echo Hello'
-	ignore:
-		- .git
-		- node_modules/
-	progress: true
-
-Notice that explicitly passed command options override the ones
-set in the configuration file.
-
-**Kind**: static method of <code>[resinSync](#module_resinSync)</code>  
-**Summary**: Sync your changes with a device  
-**Access:** public  
-
-| Param | Type | Default | Description |
-| --- | --- | --- | --- |
-| uuid | <code>String</code> |  | device uuid |
-| [options] | <code>Object</code> |  | options |
-| [options.source] | <code>String</code> | <code>$PWD</code> | source path |
-| [options.ignore] | <code>Array.&lt;String&gt;</code> |  | ignore paths |
-| [options.before] | <code>String</code> |  | command to execute before sync |
-| [options.progress] | <code>Boolean</code> | <code>true</code> | display sync progress |
-| [options.port] | <code>Number</code> | <code>22</code> | ssh port |
-
-**Example**  
-```js
-resinSync.sync('7a4e3dc', {
-  ignore: [ '.git', 'node_modules' ],
-  progress: false
-});
-```
-
-Windows
--------
+#### For Windows users:
 
 1. Install [MinGW](http://www.mingw.org).
 2. Install the `msys-rsync` and `msys-openssh` packages.
 3. Add MinGW to the `%PATH%` if this hasn't been done by the installer already. The location where the binaries are places is usually `C:\MinGW\msys\1.0\bin`, but it can vary if you selected a different location in the installer.
 4. Copy your SSH keys to `%homedrive%%homepath\.ssh`.
+
+API
+-------------
+
+This module exports two methods:
+
+#### capitano(cliTool)
+
+This returns [`capitano`](https://github.com/resin-io/capitano) command that
+can be registered by a cli tool. It is a convenience method that allows
+adding/modifying `resin sync` capitano commands/options without requiring changes in
+both the cli tool and the `resin-sync` module. The list of supported cli
+tools currently only includes 'resin-cli'
+
+Example usage in `resin-cli`:
+
+```coffeescript
+resinCliSyncCmd = require('resin-sync').capitano('resin-cli')
+capitano.command(resinCliSyncCmd)
+```
+
+#### sync(target)
+
+This method returns the proper `sync()` method for the specified `target`.
+Specifying different targets is necessary because the *application sync*
+process needs to adapt to the particular destination environment.
+
+The list of currently support targets is
+
+* `remote-resin-io-device`
+* `local-resin-os-device`
+
+and more will be added incrementally (e.g. `remote-resin-os-device`,
+`virtual-resin-os-device` etc.)
+
+The `sync()` method can be used directly by modules that don't use capitano.
 
 Support
 -------

--- a/build/capitano/index.js
+++ b/build/capitano/index.js
@@ -1,0 +1,27 @@
+
+/*
+Copyright 2016 Resin.io
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+var capitanoCommands,
+  __indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; };
+
+capitanoCommands = ['resin-cli', 'resin-toolbox'];
+
+module.exports = function(command) {
+  if ((command == null) || __indexOf.call(capitanoCommands, command) < 0) {
+    throw new Error("Invalid resin-sync capitano command '" + command + "'. Available commands are: " + capitanoCommands);
+  }
+  return require("./" + command);
+};

--- a/build/capitano/resin-cli.js
+++ b/build/capitano/resin-cli.js
@@ -1,0 +1,110 @@
+
+/*
+Copyright 2016 Resin.io
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+module.exports = {
+  signature: 'sync [uuid]',
+  description: '(beta) sync your changes to a device',
+  help: 'WARNING: If you\'re running Windows, this command only supports `cmd.exe`.\n\nUse this command to sync your local changes to a certain device on the fly.\n\nAfter every \'resin sync\' the updated settings will be saved in\n\'<source>/.resin-sync.yml\' and will be used in later invocations. You can\nalso change any option by editing \'.resin-sync.yml\' directly.\n\nHere is an example \'.resin-sync.yml\' :\n\n	$ cat $PWD/.resin-sync.yml\n	uuid: 7cf02a6\n	destination: \'/usr/src/app\'\n	before: \'echo Hello\'\n	after: \'echo Done\'\n	ignore:\n		- .git\n		- node_modules/\n\nCommand line options have precedence over the ones saved in \'.resin-sync.yml\'.\n\nIf \'.gitignore\' is found in the source directory then all explicitly listed files will be\nexcluded from the syncing process. You can choose to change this default behavior with the\n\'--skip-gitignore\' option.\n\nExamples:\n\n	$ resin sync 7cf02a6 --source . --destination /usr/src/app\n	$ resin sync 7cf02a6 -s /home/user/myResinProject -d /usr/src/app --before \'echo Hello\' --after \'echo Done\'\n	$ resin sync --ignore lib/\n	$ resin sync --verbose false\n	$ resin sync',
+  permission: 'user',
+  primary: true,
+  options: [
+    {
+      signature: 'source',
+      parameter: 'path',
+      description: 'local directory path to synchronize to device',
+      alias: 's'
+    }, {
+      signature: 'destination',
+      parameter: 'path',
+      description: 'destination path on device',
+      alias: 'd'
+    }, {
+      signature: 'ignore',
+      parameter: 'paths',
+      description: 'comma delimited paths to ignore when syncing',
+      alias: 'i'
+    }, {
+      signature: 'skip-gitignore',
+      boolean: true,
+      description: 'do not parse excluded/included files from .gitignore'
+    }, {
+      signature: 'before',
+      parameter: 'command',
+      description: 'execute a command before syncing',
+      alias: 'b'
+    }, {
+      signature: 'after',
+      parameter: 'command',
+      description: 'execute a command after syncing',
+      alias: 'a'
+    }, {
+      signature: 'port',
+      parameter: 'port',
+      description: 'ssh port',
+      alias: 't'
+    }, {
+      signature: 'progress',
+      boolean: true,
+      description: 'show progress',
+      alias: 'p'
+    }, {
+      signature: 'verbose',
+      boolean: true,
+      description: 'increase verbosity',
+      alias: 'v'
+    }
+  ],
+  action: function(params, options, done) {
+    var Promise, fs, load, path, resin, resinSync, utils;
+    fs = require('fs');
+    path = require('path');
+    resin = require('resin-sdk');
+    Promise = require('bluebird');
+    load = require('../config').load;
+    utils = require('../utils');
+    resinSync = require('../sync')('remote-resin-io-device');
+    return Promise["try"](function() {
+      try {
+        fs.accessSync(path.join(process.cwd(), '.resin-sync.yml'));
+      } catch (_error) {
+        if (options.source == null) {
+          throw new Error('No --source option passed and no \'.resin-sync.yml\' file found in current directory.');
+        }
+      }
+      if (options.source == null) {
+        options.source = process.cwd();
+      }
+      if (options.ignore != null) {
+        options.ignore = options.ignore.split(',');
+      }
+      return Promise.resolve(params.uuid).then(function(uuid) {
+        var savedUuid;
+        if (uuid == null) {
+          savedUuid = load(options.source).uuid;
+          return utils.selectResinIODevice(savedUuid);
+        }
+        return resin.models.device.has(uuid).then(function(hasDevice) {
+          if (!hasDevice) {
+            throw new Error("Device not found: " + uuid);
+          }
+          return uuid;
+        });
+      }).then(function(uuid) {
+        return resinSync(uuid, options);
+      });
+    }).nodeify(done);
+  }
+};

--- a/build/index.js
+++ b/build/index.js
@@ -1,0 +1,24 @@
+
+/*
+Copyright 2016 Resin.io
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+module.exports = {
+  capitano: function(cliTool) {
+    return require('./capitano')(cliTool);
+  },
+  sync: function(target) {
+    return require('./sync')(target);
+  }
+};

--- a/build/sync/index.js
+++ b/build/sync/index.js
@@ -1,0 +1,28 @@
+
+/*
+Copyright 2016 Resin.io
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+var syncTargets,
+  __indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; };
+
+syncTargets = ['remote-resin-io-device', 'lan-resin-os-device'];
+
+module.exports = function(target) {
+  if ((target == null) || __indexOf.call(syncTargets, target) < 0) {
+    throw new Error("Invalid resin-sync target '" + target + "'. Supported targets are: " + syncTargets);
+  }
+  console.log('require');
+  return require("./" + target);
+};

--- a/build/sync/remote-resin-io-device.js
+++ b/build/sync/remote-resin-io-device.js
@@ -32,13 +32,13 @@ Spinner = require('resin-cli-visuals').Spinner;
 
 form = require('resin-cli-form');
 
-rsync = require('./rsync');
+rsync = require('../rsync');
 
-utils = require('./utils');
+utils = require('../utils');
 
-shell = require('./shell');
+shell = require('../shell');
 
-config = require('./config');
+config = require('../config');
 
 semver = require('semver');
 
@@ -69,7 +69,7 @@ semverRegExp = /[0-9]+\.[0-9]+\.[0-9]+(?:(-|\+)[^\s]+)?/;
  *		console.log('Is incompatible')
  */
 
-exports.ensureHostOSCompatibility = ensureHostOSCompatibility = Promise.method(function(osRelease, minVersion) {
+ensureHostOSCompatibility = Promise.method(function(osRelease, minVersion) {
   var version, _ref;
   version = osRelease != null ? (_ref = osRelease.match(semverRegExp)) != null ? _ref[0] : void 0 : void 0;
   if (version == null) {
@@ -92,7 +92,7 @@ exports.ensureHostOSCompatibility = ensureHostOSCompatibility = Promise.method(f
  *
  */
 
-exports.prepareOptions = prepareOptions = Promise.method(function(uuid, cliOptions) {
+prepareOptions = Promise.method(function(uuid, cliOptions) {
   utils.validateObject(cliOptions, {
     properties: {
       source: {
@@ -186,7 +186,7 @@ exports.prepareOptions = prepareOptions = Promise.method(function(uuid, cliOptio
  *
  */
 
-exports.saveOptions = saveOptions = Promise.method(function(options, baseDir, configFile) {
+saveOptions = Promise.method(function(options, baseDir, configFile) {
   return config.save(_.pick(options, ['uuid', 'destination', 'port', 'before', 'after', 'ignore', 'skip-gitignore']), baseDir != null ? baseDir : options.source, configFile != null ? configFile : '.resin-sync.yml');
 });
 
@@ -231,7 +231,7 @@ exports.saveOptions = saveOptions = Promise.method(function(options, baseDir, co
  * @param {Number} [cliOptions.port=22] - ssh port
  *
  * @example
- * resinSync.sync('7a4e3dc', {
+ * resinSync('7a4e3dc', {
  *		source: '.',
  *		destination: '/usr/src/app',
  *   ignore: [ '.git', 'node_modules' ],
@@ -239,7 +239,7 @@ exports.saveOptions = saveOptions = Promise.method(function(options, baseDir, co
  * });
  */
 
-exports.sync = function(uuid, cliOptions) {
+module.exports = function(uuid, cliOptions) {
   var afterAction, beforeAction, clearSpinner, getDeviceInfo, spinnerPromise, startContainer, startContainerAfterError, stopContainer, syncContainer, syncOptions;
   syncOptions = {};
   clearSpinner = function(spinner, msg) {

--- a/lib/capitano/index.coffee
+++ b/lib/capitano/index.coffee
@@ -1,0 +1,27 @@
+###
+Copyright 2016 Resin.io
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+###
+
+capitanoCommands = [
+	'resin-cli'
+	'resin-toolbox'
+]
+
+module.exports = (command) ->
+
+	if not command? or command not in capitanoCommands
+		throw new Error("Invalid resin-sync capitano command '#{command}'. Available commands are: #{capitanoCommands}")
+
+	return require("./#{command}")

--- a/lib/capitano/resin-cli.coffee
+++ b/lib/capitano/resin-cli.coffee
@@ -1,0 +1,137 @@
+###
+Copyright 2016 Resin.io
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+###
+
+module.exports =
+	signature: 'sync [uuid]'
+	description: '(beta) sync your changes to a device'
+	help: '''
+		WARNING: If you're running Windows, this command only supports `cmd.exe`.
+
+		Use this command to sync your local changes to a certain device on the fly.
+
+		After every 'resin sync' the updated settings will be saved in
+		'<source>/.resin-sync.yml' and will be used in later invocations. You can
+		also change any option by editing '.resin-sync.yml' directly.
+
+		Here is an example '.resin-sync.yml' :
+
+			$ cat $PWD/.resin-sync.yml
+			uuid: 7cf02a6
+			destination: '/usr/src/app'
+			before: 'echo Hello'
+			after: 'echo Done'
+			ignore:
+				- .git
+				- node_modules/
+
+		Command line options have precedence over the ones saved in '.resin-sync.yml'.
+
+		If '.gitignore' is found in the source directory then all explicitly listed files will be
+		excluded from the syncing process. You can choose to change this default behavior with the
+		'--skip-gitignore' option.
+
+		Examples:
+
+			$ resin sync 7cf02a6 --source . --destination /usr/src/app
+			$ resin sync 7cf02a6 -s /home/user/myResinProject -d /usr/src/app --before 'echo Hello' --after 'echo Done'
+			$ resin sync --ignore lib/
+			$ resin sync --verbose false
+			$ resin sync
+	'''
+	permission: 'user'
+	primary: true
+	options: [
+			signature: 'source'
+			parameter: 'path'
+			description: 'local directory path to synchronize to device'
+			alias: 's'
+		,
+			signature: 'destination'
+			parameter: 'path'
+			description: 'destination path on device'
+			alias: 'd'
+		,
+			signature: 'ignore'
+			parameter: 'paths'
+			description: 'comma delimited paths to ignore when syncing'
+			alias: 'i'
+		,
+			signature: 'skip-gitignore'
+			boolean: true
+			description: 'do not parse excluded/included files from .gitignore'
+		,
+			signature: 'before'
+			parameter: 'command'
+			description: 'execute a command before syncing'
+			alias: 'b'
+		,
+			signature: 'after'
+			parameter: 'command'
+			description: 'execute a command after syncing'
+			alias: 'a'
+		,
+			signature: 'port'
+			parameter: 'port'
+			description: 'ssh port'
+			alias: 't'
+		,
+			signature: 'progress'
+			boolean: true
+			description: 'show progress'
+			alias: 'p'
+		,
+			signature: 'verbose'
+			boolean: true
+			description: 'increase verbosity'
+			alias: 'v'
+		,
+	]
+	action: (params, options, done) ->
+		fs = require('fs')
+		path = require('path')
+		resin = require('resin-sdk')
+		Promise = require('bluebird')
+		{ load } = require('../config')
+		utils = require('../utils')
+		resinSync = require('../sync')('remote-resin-io-device')
+
+		Promise.try ->
+			try
+				fs.accessSync(path.join(process.cwd(), '.resin-sync.yml'))
+			catch
+				if not options.source?
+					throw new Error('No --source option passed and no \'.resin-sync.yml\' file found in current directory.')
+
+			options.source ?= process.cwd()
+
+			# TODO: Add comma separated options to Capitano
+			if options.ignore?
+				options.ignore = options.ignore.split(',')
+
+			Promise.resolve(params.uuid)
+			.then (uuid) ->
+				if not uuid?
+					savedUuid = load(options.source).uuid
+					return utils.selectResinIODevice(savedUuid)
+
+				resin.models.device.has(uuid)
+				.then (hasDevice) ->
+					if not hasDevice
+						throw new Error("Device not found: #{uuid}")
+					return uuid
+			.then (uuid) ->
+				resinSync(uuid, options)
+		.nodeify(done)

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -1,0 +1,19 @@
+###
+Copyright 2016 Resin.io
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+###
+
+module.exports =
+	capitano: (cliTool) -> require('./capitano')(cliTool)
+	sync: (target) -> require('./sync')(target)

--- a/lib/sync/index.coffee
+++ b/lib/sync/index.coffee
@@ -1,0 +1,28 @@
+###
+Copyright 2016 Resin.io
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+###
+
+syncTargets = [
+	'remote-resin-io-device'
+	'lan-resin-os-device'
+]
+
+module.exports = (target) ->
+
+	if not target? or target not in syncTargets
+		throw new Error("Invalid resin-sync target '#{target}'. Supported targets are: #{syncTargets}")
+
+	console.log 'require'
+	return require("./#{target}")

--- a/lib/sync/remote-resin-io-device.coffee
+++ b/lib/sync/remote-resin-io-device.coffee
@@ -24,10 +24,10 @@ chalk = require('chalk')
 resin = require('resin-sdk')
 Spinner = require('resin-cli-visuals').Spinner
 form = require('resin-cli-form')
-rsync = require('./rsync')
-utils = require('./utils')
-shell = require('./shell')
-config = require('./config')
+rsync = require('../rsync')
+utils = require('../utils')
+shell = require('../shell')
+config = require('../config')
 semver = require('semver')
 
 MIN_HOSTOS_RSYNC = '1.1.4'
@@ -57,7 +57,7 @@ semverRegExp = /[0-9]+\.[0-9]+\.[0-9]+(?:(-|\+)[^\s]+)?/
 # .catch ->
 #		console.log('Is incompatible')
 ###
-exports.ensureHostOSCompatibility = ensureHostOSCompatibility = Promise.method (osRelease, minVersion) ->
+ensureHostOSCompatibility = Promise.method (osRelease, minVersion) ->
 	version = osRelease?.match(semverRegExp)?[0]
 	if not version?
 		throw new Error("Could not parse semantic version from HostOS release info: #{osRelease}")
@@ -75,7 +75,7 @@ exports.ensureHostOSCompatibility = ensureHostOSCompatibility = Promise.method (
 # @returns {Promise} options - the options to use for this resin sync run
 #
 ###
-exports.prepareOptions = prepareOptions = Promise.method (uuid, cliOptions) ->
+prepareOptions = Promise.method (uuid, cliOptions) ->
 	utils.validateObject cliOptions,
 		properties:
 			source:
@@ -162,7 +162,7 @@ exports.prepareOptions = prepareOptions = Promise.method (uuid, cliOptions) ->
 # @returns {Promise} - Promise is rejected if file could not be saved
 #
 ###
-exports.saveOptions = saveOptions = Promise.method (options, baseDir, configFile) ->
+saveOptions = Promise.method (options, baseDir, configFile) ->
 
 	config.save(
 		_.pick(
@@ -213,14 +213,14 @@ exports.saveOptions = saveOptions = Promise.method (options, baseDir, configFile
 # @param {Number} [cliOptions.port=22] - ssh port
 #
 # @example
-# resinSync.sync('7a4e3dc', {
+# resinSync('7a4e3dc', {
 #		source: '.',
 #		destination: '/usr/src/app',
 #   ignore: [ '.git', 'node_modules' ],
 #   progress: false
 # });
 ###
-exports.sync = (uuid, cliOptions) ->
+module.exports = (uuid, cliOptions) ->
 
 	syncOptions = {}
 

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -16,6 +16,8 @@ limitations under the License.
 
 _ = require('lodash')
 revalidator = require('revalidator')
+form = require('resin-cli-form')
+resin = require('resin-sdk')
 
 ###*
 # @summary Validate object
@@ -117,3 +119,21 @@ exports.gitignoreToRsyncPatterns = (gitignoreFile) ->
 		include: _.uniq(include)
 		exclude: _.uniq(exclude)
 	}
+
+exports.selectResinIODevice = (preferredUuid) ->
+	resin.models.device.getAll()
+	.filter (device) ->
+		device.is_online
+	.then (onlineDevices) ->
+		if _.isEmpty(onlineDevices)
+			throw new Error('You don\'t have any devices online')
+
+		return form.ask
+			message: 'Select a device'
+			type: 'list'
+			default: if preferredUuid in _.map(onlineDevices, 'uuid') then preferredUuid else onlineDevices[0].uuid
+			choices: _.map onlineDevices, (device) ->
+				return {
+					name: "#{device.name or 'Untitled'} (#{device.uuid.slice(0, 7)})"
+					value: device.uuid
+				}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "resin-sync",
   "version": "3.1.7",
   "description": "Watch a local project directory and sync it on the fly",
-  "main": "build/sync.js",
+  "main": "build/index.js",
   "homepage": "https://github.com/resin-io-modules/resin-sync",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Closes #42 

After that it will be possible to replace [lib/actions/sync.coffee](https://github.com/resin-io/resin-cli/blob/master/lib/actions/sync.coffee) in `resin-cli`with:

``` coffeescript
module.exports = require('resin-sync').capitano('resin-cli')
```

More capitano frontends can then be added for other capitano-based tools (e.g. `resin-toolbox`)
