### PR TITLE
rdt: stream logs when a container is running, only print log history otherwise

### DIFF
--- a/lib/docker-utils.coffee
+++ b/lib/docker-utils.coffee
@@ -305,9 +305,14 @@ module.exports =
 		pipeContainerStream: (name, outStream) ->
 			Promise.try ->
 				ensureDockerInit()
-				docker.getContainer(name).attachAsync
-					stream: true
-					stdout: true
-					stderr: true
+				container = docker.getContainer(name)
+				container.inspectAsync().then (containerInfo) ->
+					return containerInfo?.State?.Running
+				.then (isRunning) ->
+					container.attachAsync
+						logs: not isRunning
+						stream: isRunning
+						stdout: true
+						stderr: true
 				.then (containerStream) ->
 					containerStream.pipe(outStream)


### PR DESCRIPTION
Closes #90 
