### PR TITLE
Chore: refactor to improve project maintainability

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -21,7 +21,7 @@ gulp.task 'coffee', ->
 gulp.task 'test', ['lint'], ->
 	gulp.src(OPTIONS.files.tests, read: false)
 		.pipe(mocha({
-			reporter: 'min'
+			bail: true
 		}))
 
 gulp.task 'lint', ['coffee'], ->

--- a/lib/build-trigger.coffee
+++ b/lib/build-trigger.coffee
@@ -1,0 +1,138 @@
+###*
+# Helper methods for build-trigger `rdt push` feature
+# @module build-trigger
+###
+
+fs = require('fs')
+path = require('path')
+crypto = require('crypto')
+Promise = require('bluebird')
+_ = require('lodash')
+TypedError = require('typed-error')
+{ fileExists } = require('./utils')
+
+class FileChangedError extends TypedError
+
+###*
+# @summary Return file hash - based on https://nodejs.org/api/crypto.html
+# @function getFileHash
+#
+# @param {String} file - file path
+# @param {String} [algo='sha256'] - Hash algorithm
+#
+# @returns {Promise}
+# @throws Exception on error
+#
+# @example
+# getFileHash('package.json').then (hash) ->
+#		console.log('hash')
+###
+exports.getFileHash = getFileHash = Promise.method (file, algo = 'sha256') ->
+	new Promise (resolve, reject) ->
+		try
+			hash = crypto.createHash(algo)
+			input = fs.createReadStream(file)
+			input.on 'readable', ->
+				data = input.read()
+				if data?
+					return hash.update(data)
+				return resolve(hash.digest('hex'))
+			.on('error', reject)
+		catch err
+			reject(err)
+
+###*
+# @summary Creates an array of objects with the hashes of the passed files
+# @function
+#
+# @param {Object} options - options
+# @param {String[]} [options.files=[]] - array of file paths to calculate hashes
+# @param {String} [options.baseDir=process.cwd()] - Base directory for relative file paths
+# @param {Boolean} [options.skipMissing=true] - Skip non-existent files from the 'files' array
+#
+# @returns {Promise}
+# @throws Exception on error or if 'skipMissing' is false and a file in the 'files' array does not exis
+#
+# @example
+# createBuildTriggerHashes({ files: [ 'package.json', 'Dockerfile' ] }).then (hashes) ->
+# // resolves with 'hashes' array:
+# [
+#		{ 'package.json': <sha256> }
+#		{ 'Dockerfile': <sha256> }
+#	]
+#
+###
+module.exports.createBuildTriggerHashes = Promise.method ({ files = [], baseDir = process.cwd(), skipMissing = true }) ->
+	# Dockerfile and package.json are always included as build triggers
+	buildTriggers = _.union(files, [ 'Dockerfile', 'package.json' ])
+
+	buildTriggers = _.chain(buildTriggers)
+		.filter (filename) ->
+			# Filter out empty 'build-triggers' file names (e.g. when passing 'package.json,,,trigger.txt')
+			not _.isEmpty(filename)
+		.map (filename) ->
+			return filename.trim()
+		.map (filename) ->
+			# return full path to easily remove duplicates
+			if not path.isAbsolute(filename)
+				return path.join(baseDir, filename)
+			return filename
+		.uniq()
+		.filter (filename) ->
+			if not fileExists(filename)
+				throw new Error("Could not calculate hash - File does not exist: #{filename}") if not skipMissing
+				return false
+			return true
+		.map (filename) ->
+			# We prefer to save relative file paths in rdt yaml config so that the paths will still be valid
+			# if the yaml config (i.e. `resin-sync.yml`) is checked into a git repo and then cloned to another
+			# workstation
+			path.relative(baseDir, filename)
+		.value()
+
+	Promise.map buildTriggers, (filename) ->
+		getFileHash(path.join(baseDir, filename))
+		.then (hash) ->
+			result = {}
+			result[filename] = hash
+
+			return result
+
+###*
+# @summary Checks if any of the files in the build trigger list has changed or is missing
+# @function checkTriggers
+#
+# @param {Object} buildTriggers - Array of { filePath: hash } objects
+# @param {String} [baseDir=process.cwd()] - Base directory for relative file paths in 'buildTriggers'
+#
+# @returns {Promise} - Resolves with true if any file hash has changed or any of the files was missing,
+# false otherwise
+# @throws Exception on error
+#
+# @example
+# checkTriggers('package.json': 1234, 'Dockerfile': 5678).then (triggered) ->
+#		console.log(triggered)
+###
+module.exports.checkTriggers = Promise.method (buildTriggers, baseDir = process.cwd()) ->
+	if _.isEmpty(buildTriggers)
+		return false
+
+	Promise.map buildTriggers, (trigger) ->
+		[ filename, saved_hash ] = _.toPairs(trigger)[0]
+
+		filename = path.join(baseDir, filename)
+
+		if not fileExists(filename)
+			throw new FileChangedError('File missing:', filename)
+
+		getFileHash(filename)
+		.then (hash) ->
+			if hash isnt saved_hash
+				throw new FileChangedError('File changed:', filename)
+	.then ->
+		return false
+	.catch FileChangedError, (err) ->
+		return true
+	.catch (err) ->
+		console.log('[Warning] Error while checking build trigger hashes', err?.message ? err)
+		return true

--- a/lib/capitano/parse-options.coffee
+++ b/lib/capitano/parse-options.coffee
@@ -1,0 +1,72 @@
+path = require('path')
+_ = require('lodash')
+yamlConfig = require('../yaml-config')
+{ fileExists } = require('../utils')
+
+defaultSyncIgnorePaths = [ '.git', 'node_modules/' ]
+
+###*
+# @summary Parse rdt/resin sync options from the cli and config file and give precedece to the cli.
+# @function
+#
+# @param {Object} cliOptions - options
+# @param {String} cliParams - parameters
+#
+# @returns {Object} parsedOptions
+# @returns {Object} parsedOptions.configYml - the loaded config file (i.e. 'resin-sync.yml')
+# @returns {Object} parsedOptions.options - the parsed options
+# @throws Exception on error
+#
+###
+module.exports = (cliOptions = {}, cliParams = {}) ->
+
+	# The project base directory is either the current working directory or the directory passed by
+	# the user with the '--source/-s' option
+	projectBaseDir = cliOptions['source'] ? process.cwd()
+
+	if not cliOptions['source']? and not fileExists(path.join(process.cwd(), yamlConfig.CONFIG_FILE))
+		throw new Error("No --source option passed and no \'#{yamlConfig.CONFIG_FILE}\' file found in current directory.")
+
+	# The yaml-as-JS-object variable to hold CONFIG_FILE (currently '.resin-sync.yml') contents
+	configYml = yamlConfig.load(projectBaseDir)
+	configYml['local_resinos'] ?= {}
+
+	# Capitano does not support comma separated options yet
+	if cliOptions['build-triggers']?
+		cliOptions['build-triggers'] = cliOptions['build-triggers'].split(',')
+
+	# Parse build trigger files and their hashes from the config file
+	savedBuildTriggers = configYml['local_resinos']['build-triggers'] ? []
+	savedBuildTriggerFiles = _.flatten(file for file of trigger for trigger in savedBuildTriggers)
+
+	# Ditto on capitano comma separated options
+	if cliOptions['ignore']?
+		cliOptions['ignore'] = cliOptions['ignore'].split(',')
+
+	ignoreFiles = cliOptions['ignore'] ? configYml['ignore'] ? defaultSyncIgnorePaths
+
+	# Filter out empty 'ignore' paths
+	ignoreFiles = _.filter(ignoreFiles, (item) -> not _.isEmpty(item))
+
+	# Return parsed options and give precedence to command line options
+	# in favor of the ones saved in the config file
+	return {
+		configYml: configYml
+		runtimeOptions:
+			baseDir: projectBaseDir
+			deviceIp: cliParams['deviceIp']
+			appName: cliOptions['app-name'] ? configYml['local_resinos']['app-name']
+			destination: cliOptions['destination'] ? configYml['destination']
+			before: cliOptions['before'] ? configYml['before']
+			after: cliOptions['after'] ? configYml['after']
+			progress: cliOptions['progress'] ? false
+			verbose: cliOptions['verbose'] ? false
+			skipGitignore: cliOptions['skip-gitignore'] ? false
+			ignore: ignoreFiles
+			skipLogs: cliOptions['skip-logs'] ? false
+			forceBuild: cliOptions['force-build'] ? false
+			buildTriggerFiles: cliOptions['build-triggers'] ? savedBuildTriggerFiles
+			savedBuildTriggerFiles: savedBuildTriggerFiles
+			uuid: cliParams['uuid']
+			port: cliOptions['port']
+	}

--- a/lib/capitano/resin-toolbox.coffee
+++ b/lib/capitano/resin-toolbox.coffee
@@ -117,297 +117,168 @@ module.exports =
 			alias: 'f'
 	]
 	action: (params, options, done) ->
-		fs = require('fs')
 		path = require('path')
-		crypto = require('crypto')
 		Promise = require('bluebird')
 		_ = require('lodash')
 		chalk = require('chalk')
-		form = require('resin-cli-form')
-		{ save } = require('../config')
-		{ getSyncOptions, loadResinSyncYml } = require('../utils')
-		{ selectLocalResinOsDeviceForm } = require('../discover')
-		{ dockerInit
-			checkForExistingImage
-			checkForRunningContainer
-			buildImage
-			removeImage
-			inspectImage
-			createContainer
-			startContainer
-			stopContainer
-			removeContainer
-			pipeContainerStream } = require('../docker-utils')
+		yamlConfig = require('../yaml-config')
+		parseOptions = require('./parse-options')
+		RdtDockerUtils = require('../docker-utils')
+		{ selectAppName, selectSyncDestination, selectLocalResinOsDevice } = require('../forms')
+		{ fileExists } = require('../utils')
 		{ sync } = require('../sync')('local-resin-os-device')
+		{ createBuildTriggerHashes, checkTriggers } = require('../build-trigger')
 
-		# Saves selected app name in '.resin-sync.yml` and resolves with its value.
-		# Throws if app name is invalid or '.resin-sync.yml' could not be updated.
-		setAppName = Promise.method (resinSyncYml, preferredAppName) ->
-
-			# Resolves with passed 'appName' if it's valid, throws otherwise
-			validateAppName = Promise.method (appName) ->
-				validCharsRegExp = new RegExp('^[a-z0-9-]+$')
-
-				if _.isEmpty(appName)
-					throw new Error('Application name should not be empty.')
-
-				hasValidChars = validCharsRegExp.test(appName)
-
-				if not hasValidChars or _.startsWith(appName, '-') or _.endsWith(appName, '-')
-					throw new Error('Application name may only contain lowercase characters, digits and one or more dashes. It may not start or end with a dash.')
-
-				return appName
-
-			form.run [
-				message: 'Select a name for the application'
-				name: 'appname'
-				type: 'input'
-			],
-				override:
-					appname: preferredAppName
-			.get('appname')
-			.call('trim')
-			.then(validateAppName)
-			.tap (appName) ->
-				resinSyncYml['local_resinos']['app-name'] = appName
-				save(_.omit(resinSyncYml, [ 'source' ]), resinSyncYml.source)
-
-		# Returns true if it does, false if it doesnt and throws synchronously on error
-		checkFileExistsSync = (filename) ->
-			try
-				fs.accessSync(filename)
-				return true
-			catch err
-				if err.code is 'ENOENT'
-					return false
-				throw new Error("Could not access #{filename}: #{err}")
-
-		ensureDockerfileExists = Promise.method (baseDir) ->
-			baseDir ?= process.cwd()
-			dockerfileExists = checkFileExistsSync(path.join(baseDir, 'Dockerfile'))
-
-			if not dockerfileExists
-				throw new Error("No Dockerfile was found in the project directory: #{baseDir}")
-
-		getDeviceIp = Promise.method (deviceIp) ->
-			if deviceIp?
-				return deviceIp
-			return selectLocalResinOsDeviceForm()
-
-		# https://nodejs.org/api/crypto.html
-		getFileHash = Promise.method (file, algo = 'sha256') ->
-			new Promise (resolve, reject) ->
-				try
-
-					hash = crypto.createHash(algo)
-					input = fs.createReadStream(file)
-					input.on 'readable', ->
-						data = input.read()
-						if data?
-							return hash.update(data)
-						return resolve(hash.digest('hex'))
-					.on('error', reject)
-				catch err
-					reject(err)
-
-		# Takes a list of files ('buildTriggers') located in 'baseDir' and returns an object with their hashes:
-		# Input: [ 'package.json', 'requirements.txt', 'Othertrigger' ]
-		# Output: {
-		#		'package_json': <sha256>
-		#		'requiremenets_txt': <sha256>
-		#		'Othertrigger': <sha256>
-		#	}
-		createBuildTriggerHashes = Promise.method (baseDir, buildTriggersList = []) ->
-
-			if not baseDir?
-				throw new Error('baseDir is required to create build trigger hashes')
-
-			# Dockerfile and package.json are always included as build triggers
-			buildTriggersList = _.union(buildTriggersList, [ 'Dockerfile', 'package.json' ])
-
-			# Filter out empty 'build-triggers' file names (e.g. when passing 'package.json,,,trigger.txt')
-			# and files that cannot be accessed
-			buildTriggersList = _.chain(buildTriggersList)
-				.filter((filename) -> not _.isEmpty(filename))
-				.map((filename) -> return filename.trim())
-				.filter (filename) ->
-					checkFileExistsSync(path.join(baseDir, filename))
-				.value()
-
-			Promise.map buildTriggersList, (filename) ->
-				getFileHash(filename)
-				.then (hash) ->
-					result = {}
-					result[filename] = hash
-
-					return result
-
-		setBuildTriggerHashes = Promise.method (resinSyncYml, buildTriggersList = []) ->
-			createBuildTriggerHashes(resinSyncYml['source'], buildTriggersList)
-			.then (buildTriggerHashes) ->
-				resinSyncYml['local_resinos']['build-triggers'] = buildTriggerHashes
-				save(_.omit(resinSyncYml, [ 'source' ]), resinSyncYml.source)
-
-		# resolved with 'true', if any hash has changed or if any of the files
-		# listed in local_resinos: build-triggers could not be accessed or was missing.
+		###*
+		# @summary Start image-building 'rdt push' process
+		# @function build
 		#
-		# resolves with 'false' if the hashes in local_resinos: build-triggers  match
-		# the ones of the corresponding files on the filesystem.
-		checkBuildTriggers = Promise.method (resinSyncYml) ->
+		# @param {Object} options - options
+		# @param {String} options.appName - Application image (i.e. image & container name)
+		# @param {String} options.deviceIp - Device ip or host
+		# @param {String} [options.baseDir=process.cwd()] - Project base directory that also containers Dockerfile
+		#
+		# @returns {} - Exits process with 0 on success or 1 otherwise
+		# @throws Exception on error
+		#
+		# @example
+		# build(appName: 'test', deviceIp: '192.168.1.1')
+		###
+		build = ({ appName, deviceIp, baseDir = process.cwd() } = {}) ->
+			throw new Error("Missing application name for 'rtd push'") if not appName?
+			throw new Error("Missing device ip/host for 'rtd push'") if not deviceIp?
 
-			savedBuildTriggers = resinSyncYml?['local_resinos']?['build-triggers']
-			if not savedBuildTriggers
-				return true
-
-			baseDir = resinSyncYml['source']
-
-			Promise.map savedBuildTriggers, (trigger) ->
-				[ filename, saved_hash ] = _.toPairs(trigger)[0]
-
-				filename = path.join(baseDir, filename)
-
-				# First, check if any of the files in 'savedBuildTriggers' is missing or is not accessible
-				fileExists = checkFileExistsSync(filename)
-				if not fileExists
-					return true
-
-				# Then, check if its hash has changed
-				getFileHash(filename)
-				.then (hash) ->
-					if hash isnt saved_hash
-						return true
-					return false
-			.then (results) ->
-				true in results
-			.catch (err) ->
-				console.log('Error while checking build trigger hashes', err)
-				return true
-
-		followContainerLogs = Promise.method (appName, outStream = process.stdout) ->
-			if not appName?
-				throw new Error('Please give an application name to stream logs from')
-
-			console.log(chalk.yellow.bold('* Streaming application logs..'))
-			pipeContainerStream(appName, outStream)
-			.catch (err) ->
-				console.log('Could not stream application logs.', err)
-
-		buildAction = ({ appName, buildDir = process.cwd(), outStream = process.stdout, skipLogs = false } = {}) ->
-			if not appName?
-				throw new Error('Please give an application name to build')
+			docker = new RdtDockerUtils(deviceIp)
 
 			console.log(chalk.yellow.bold('* Building..'))
 
 			console.log "- Stopping and Removing any previous '#{appName}' container"
-			stopContainer(appName)
+			docker.stopContainer(appName)
 			.then ->
-				removeContainer(appName)
+				docker.removeContainer(appName)
 			.then ->
 				# Get existing image id and remove it after building new one to preserve build cache
-				inspectImage(appName)
+				docker.inspectImage(appName)
 				.catch (err) ->
 					statusCode = '' + err.statusCode
 					return null if statusCode is '404'
 					throw err
 			.then (oldImageInfo) ->
 				console.log "- Building new '#{appName}' image"
-				buildImage
-					baseDir: buildDir ? process.cwd()
+				docker.buildImage
+					baseDir: baseDir
 					name: appName
-					outStream: outStream ? process.stdout
+					outStream: process.stdout
 				.then ->
 					# Clean up previous image only if new build resulted in different image hash
-					inspectImage(appName)
+					docker.inspectImage(appName)
 				.then (newImageInfo) ->
 					if oldImageInfo? and oldImageInfo.Id isnt newImageInfo.Id
 						console.log "- Cleaning up previous image of '#{appName}'"
-						removeImage(oldImageInfo.Id)
+						docker.removeImage(oldImageInfo.Id)
 			.then ->
 				console.log "- Creating '#{appName}' container"
-				createContainer(appName)
+				docker.createContainer(appName)
 			.then ->
 				console.log "- Starting '#{appName}' container"
-				startContainer(appName)
-			.then ->
-				console.log(chalk.green.bold('\nrdt push completed successfully!'))
-			.catch (err) ->
-				console.log(chalk.red.bold('rdt push failed.', err))
-				process.exit(1)
-			.then ->
-				followContainerLogs(appName, process.stdout) if not skipLogs
+				docker.startContainer(appName)
 
-		syncAction = ({ cliOptions, deviceIp, appName, skipLogs = false } = {}) ->
-			throw new Error('Device IP is required for sync action') if not deviceIp?
-			throw new Error('Application name is required for sync action') if not appName?
+		# Parse cli options and parameters
+		{ runtimeOptions, configYml } = parseOptions(options, params)
 
-			console.log(chalk.yellow.bold('* Syncing..'))
-			getSyncOptions(cliOptions)
-			.then (syncOptions) ->
-				sync(syncOptions, deviceIp)
-			.then ->
-				console.log(chalk.green.bold('\nrdt push completed successfully!'))
-			.catch (err) ->
-				console.log(chalk.red.bold('rdt push failed.', err))
-				process.exit(1)
-			.then ->
-				followContainerLogs(appName, process.stdout) if not skipLogs
+		if not fileExists(path.join(runtimeOptions.baseDir, 'Dockerfile'))
+			throw new Error("No Dockerfile was found in the project directory: #{runtimeOptions.baseDir}")
 
-		# Capitano does not support comma separated options yet
-		if options['build-triggers']?
-			options['build-triggers'] = options['build-triggers'].split(',')
+		Promise.try ->
+			# Get device Ip and app name, giving precedence to the cli param
+			runtimeOptions.deviceIp ? selectLocalResinOsDevice()
+		.then (deviceIp) ->
+			Promise.props
+				deviceIp: deviceIp
+				appName: selectAppName(runtimeOptions.appName)
+		.then ({ deviceIp, appName }) ->
 
-		cliBuildTriggersList = options['build-triggers']
-		cliAppName = options['app-name']
-		cliForceBuild = options['force-build'] ? false
+			# Update runtime options and soon-to-be-saved config file object based on user choices
+			runtimeOptions.deviceIp = deviceIp
+			runtimeOptions.appName = appName
+			configYml['local_resinos']['app-name'] = appName
 
-		# XXX: capitano defaults non-passed boolean options to 'false' and does not seem
-		# to recognize 'default' option configuration setting
-		cliSkipLogs = options['skip-logs'] ? false
+			docker = new RdtDockerUtils(deviceIp)
 
-		loadResinSyncYml(options.source)
-		.then (@resinSyncYml) =>
-			ensureDockerfileExists()
-		.then ->
-			getDeviceIp(params.deviceIp)
-		.then (@deviceIp) =>
-			dockerInit(@deviceIp)
-		.then =>
-			if not @resinSyncYml['local_resinos']?
-				@resinSyncYml['local_resinos'] = {}
-
-			# Give precedence to cli passed 'app-name'
-			appName = cliAppName ? @resinSyncYml['local_resinos']['app-name']
-			setAppName(@resinSyncYml, appName)
-		.then (appName) =>
-
-			savedBuildTriggers = @resinSyncYml['local_resinos']['build-triggers']
-			savedBuildTriggersList = _.map savedBuildTriggers, (trigger) -> _.toPairs(trigger)[0][0]
-
-			buildDir = @resinSyncYml['source']
-
-			# If builder trigger list is empty in resin sync yml or explicit 'build-trigger'
-			# option was passed then force rebuild
-			if _.isEmpty(savedBuildTriggers) or cliBuildTriggersList?
-				return setBuildTriggerHashes(@resinSyncYml, cliBuildTriggersList).then ->
-					buildAction({ appName, buildDir, skipLogs: cliSkipLogs })
-
-			# If '--force-build' action is passed, rebuild
-			if cliForceBuild
-				return buildAction({ appName, buildDir, skipLogs: cliSkipLogs })
-
-			checkBuildTriggers(@resinSyncYml)
-			.then (shouldRebuild) =>
-
-				# Recalculate and save all trigger hashes and rebuild if any of the saved ones has changed
+			# The project should be rebuilt if any of the following is true:
+			#		- The saved build trigger list in yamlConfig is empty or the cli 'build-trigger' option was set
+			#		- The 'force-build' cli option was set
+			#		- Any of the saved build trigger files is modified
+			#		- The application image does not exist or the container is not running
+			configYmlBuildTriggers = configYml['local_resinos']['build-triggers']
+			Promise.reduce([
+				_.isEmpty(configYmlBuildTriggers) or not _.isEmpty(options['build-triggers'])
+				runtimeOptions.forceBuild
+				checkTriggers(configYmlBuildTriggers)
+				docker.checkForExistingImage(appName).then((exists) -> not exists) # return 'true' if image does not exist
+				docker.checkForRunningContainer(appName).then((isRunning) -> not isRunning) # return 'true' if container is not running
+			]
+			, (shouldRebuild, result, index) ->
+				shouldRebuild or result
+			, false)
+			.then (shouldRebuild) ->
 				if shouldRebuild
-					return setBuildTriggerHashes(@resinSyncYml, savedBuildTriggersList).then ->
-						buildAction({ appName, buildDir, skipLogs: cliSkipLogs })
 
-				Promise.props
-					containerIsRunning: checkForRunningContainer(appName)
-					imageExists: checkForExistingImage(appName)
-				.then ({ containerIsRunning, imageExists }) =>
-					if imageExists and containerIsRunning
-						return syncAction({ appName, cliOptions: options, deviceIp: @deviceIp, skipLogs: cliSkipLogs })
-					return buildAction({ appName, buildDir, skipLogs: cliSkipLogs })
+					# Calculate new hashes
+					createBuildTriggerHashes(baseDir: runtimeOptions.baseDir, files: runtimeOptions.buildTriggerFiles)
+					.then (buildTriggerHashes) ->
+						configYml['local_resinos']['build-triggers'] = buildTriggerHashes
+
+						# Save config file before starting build
+						yamlConfig.save(
+							configYml
+							runtimeOptions.baseDir
+						)
+
+						build _.pick runtimeOptions, [
+							'baseDir'
+							'deviceIp'
+							'appName'
+						]
+				else
+					console.log(chalk.yellow.bold('* Syncing..'))
+					selectSyncDestination(runtimeOptions.destination)
+					.then (destination) ->
+
+						# Update runtime options based on user choices
+						runtimeOptions.destination = destination
+
+						# Save config file before starting sync
+						notNil = (val) -> not _.isNil(val)
+						yamlConfig.save(
+							_.assign({}, configYml, _(runtimeOptions).pick([ 'destination', 'ignore', 'before', 'after' ]).pickBy(notNil).value())
+							runtimeOptions.baseDir
+						)
+
+						sync _.pick runtimeOptions, [
+							'baseDir'
+							'deviceIp'
+							'appName'
+							'destination'
+							'before'
+							'after'
+							'progress'
+							'verbose'
+							'skipGitignore'
+							'ignore'
+						]
+			.then ->
+				console.log(chalk.green.bold('\nrdt push completed successfully!'))
+			.catch (err) ->
+				console.log(chalk.red.bold('rdt push failed.', err, err.stack))
+				process.exit(1)
+			.then ->
+				if runtimeOptions.skipLogs is true
+					return process.exit(0)
+
+				console.log(chalk.yellow.bold('* Streaming application logs..'))
+				docker.followContainerLogs(appName)
+				.catch (err) ->
+					console.log('[Info] Could not stream logs from container', err)
+					process.exit(0)
 		.nodeify(done)

--- a/lib/discover.coffee
+++ b/lib/discover.coffee
@@ -17,8 +17,6 @@ limitations under the License.
 _ = require('lodash')
 resin = require('resin-sdk')
 { enumerateServices, findServices } = require('resin-discoverable-services')
-form = require('resin-cli-form')
-{ SpinnerPromise } = require('resin-cli-visuals')
 
 # Although we only check for 'resin-ssh', we know, implicitly, that resinOS
 # devices come with 'rsync' installed that can be used over SSH.
@@ -41,25 +39,6 @@ exports.discoverLocalResinOsDevices = (timeout = 4000) ->
 			{ referer: address: address, host, port } = service
 
 			return { address, host, port }
-
-exports.selectLocalResinOsDeviceForm = (timeout = 4000) ->
-	new SpinnerPromise
-		promise: exports.discoverLocalResinOsDevices()
-		startMessage: 'Discovering local resinOS devices..'
-		stopMessage: 'Reporting discovered devices'
-	.then (devices) ->
-		if _.isEmpty(devices)
-			throw new Error('Could not find any local resinOS devices')
-
-		return form.ask
-			message: 'select a device'
-			type: 'list'
-			default: devices[0].ip
-			choices: _.map devices, (device) ->
-				return {
-					name: "#{device.host or 'untitled'} (#{device.address})"
-					value: device.address
-				}
 
 # Resolves with array of remote online Resin.io devices, throws on error
 exports.getRemoteResinioOnlineDevices = ->

--- a/lib/forms.coffee
+++ b/lib/forms.coffee
@@ -1,0 +1,68 @@
+Promise = require('bluebird')
+_ = require('lodash')
+form = require('resin-cli-form')
+{ discoverLocalResinOsDevices } = require('./discover')
+{ SpinnerPromise } = require('resin-cli-visuals')
+
+# Presents interactive dialog to choose an application name if no preferred application name
+# is passed as a parameter.
+#
+# Resolves with selected application name if it is valid, throws otherwise
+exports.selectAppName = (preferredAppName) ->
+	# Helper function that Resolves with passed 'appName' if it's valid or throws otherwise
+	validateAppName = Promise.method (appName) ->
+		validCharsRegExp = new RegExp('^[a-z0-9-]+$')
+
+		if _.isEmpty(appName)
+			throw new Error('Application name should not be empty.')
+
+		hasValidChars = validCharsRegExp.test(appName)
+
+		if not hasValidChars or _.startsWith(appName, '-') or _.endsWith(appName, '-')
+			throw new Error('Application name may only contain lowercase characters, digits and one or more dashes. It may not start or end with a dash.')
+
+		return appName
+
+	form.run [
+		message: 'Select a name for the application'
+		name: 'appname'
+		type: 'input'
+	],
+		override:
+			appname: preferredAppName
+	.get('appname')
+	.call('trim')
+	.then(validateAppName)
+
+# Select a sync destination folder
+exports.selectSyncDestination = (preferredDestination) ->
+	form.run [
+		message: 'Destination directory on device container [/usr/src/app]'
+		name: 'destination'
+		type: 'input'
+	],
+		override:
+			destination: preferredDestination
+	.get('destination')
+	.then (destination) ->
+		destination ? '/usr/src/app'
+
+
+exports.selectLocalResinOsDevice = (timeout = 4000) ->
+	new SpinnerPromise
+		promise: discoverLocalResinOsDevices(timeout)
+		startMessage: 'Discovering local resinOS devices..'
+		stopMessage: 'Reporting discovered devices'
+	.then (devices) ->
+		if _.isEmpty(devices)
+			throw new Error('Could not find any local resinOS devices')
+
+		return form.ask
+			message: 'select a device'
+			type: 'list'
+			default: devices[0].ip
+			choices: _.map devices, (device) ->
+				return {
+					name: "#{device.host or 'untitled'} (#{device.address})"
+					value: device.address
+				}

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -17,5 +17,5 @@ limitations under the License.
 module.exports =
 	capitano: (cliTool) -> require('./capitano')(cliTool)
 	sync: (target) -> require('./sync')(target)
-	config: require('./config')
-	discover: require('./discover')
+	config: require('./yaml-config')
+	forms: require('./forms')

--- a/lib/rsync.coffee
+++ b/lib/rsync.coffee
@@ -34,6 +34,9 @@ buildRshOption = (options = {}) ->
 			verbose:
 				description: 'verbose'
 				type: 'boolean'
+			extraSshOptions:
+				description: 'extraSshOptions'
+				type: 'string'
 
 	verbose = if options.verbose then '-vv ' else ''
 
@@ -47,6 +50,8 @@ buildRshOption = (options = {}) ->
 		-o ControlMaster=no
 	"""
 
+	sshCommand += " #{options.extraSshOptions}" if options.extraSshOptions?
+
 	return sshCommand
 
 ###*
@@ -55,14 +60,15 @@ buildRshOption = (options = {}) ->
 # @protected
 #
 # @param {Object} options - rsync options
-# @param {String} options.host - host
 # @param {String} options.username - username
+# @param {String} options.host - host
 # @param {Boolean} [options.progress] - show progress
 # @param {String|String[]} [options.ignore] - pattern/s to ignore. Note that '.gitignore' is always used as a filter if it exists
+# @param {Boolean} [options.skipGitignore] - skip gitignore
 # @param {Boolean} [options.verbose] - verbose output
-# @param {Boolean} [options.skip-gitignore] - skip gitignore
 # @param {String} options.source - source directory on local machine
 # @param {String} options.destination - destination directory on device
+# @param {String} options.rsyncPath - set --rsync-path rsync option
 #
 # @returns {String} rsync command
 #
@@ -96,7 +102,7 @@ exports.buildRsyncCommand = (options = {}) ->
 				description: 'ignore'
 				type: [ 'string', 'array' ]
 				message: 'Not a string or array: ignore'
-			'skip-gitignore':
+			skipGitignore:
 				description: 'skip-gitignore'
 				type: 'boolean'
 				message: 'Not a boolean: skip-gitignore'
@@ -114,7 +120,7 @@ exports.buildRsyncCommand = (options = {}) ->
 				type: 'any'
 				required: true
 				message: 'Not a string: destination'
-			'rsync-path':
+			rsyncPath:
 				description: 'rsync path'
 				type: 'string'
 				message: 'Not a string: rsync-path'
@@ -138,10 +144,10 @@ exports.buildRsyncCommand = (options = {}) ->
 
 	rsyncCmd = rsync.build(args).delete()
 
-	if options['rsync-path']?
-		rsyncCmd.set('rsync-path', options['rsync-path'])
+	if options['rsyncPath']?
+		rsyncCmd.set('rsync-path', options['rsyncPath'])
 
-	if not options['skip-gitignore']
+	if not options['skipGitignore']
 		try
 			patterns = utils.gitignoreToRsyncPatterns(path.join(options.source, '.gitignore'))
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "JSONStream": "^1.2.1",
-    "bluebird": "^2.10.1",
+    "bluebird": "^3.4.6",
     "chalk": "^1.1.3",
     "docker-toolbelt": "^1.2.1",
     "js-yaml": "^3.4.2",
@@ -55,6 +55,7 @@
     "shellwords": "^0.1.0",
     "ssh2": "^0.5.2",
     "tar-fs": "^1.13.2",
+    "typed-error": "^0.1.0",
     "underscore.string": "^3.2.3"
   }
 }

--- a/tests/build-trigger.spec.coffee
+++ b/tests/build-trigger.spec.coffee
@@ -1,0 +1,75 @@
+m = require('mochainon')
+path = require('path')
+_ = require('lodash')
+mockFs = require('mock-fs')
+{ getFileHash, createBuildTriggerHashes, checkTriggers } = require('../lib/build-trigger')
+
+filesystem =
+	'package.json': 'package.json contents'
+	'Dockerfile': 'Dockerfile contents'
+
+savedBuildTriggers = [
+	{ 'package.json': 'e2c193459707068888808a4e89c745162ed4e24bc093ac72f0009f5f15992cbb' }
+	{ 'Dockerfile': 'f6aca399ab7883e1ebdf61b6d22756df83626409f824c0f6d80c2148478769b2' }
+]
+
+describe 'build-trigger', ->
+	beforeEach ->
+		mockFs(filesystem)
+
+	afterEach ->
+		mockFs.restore()
+
+	describe 'getFileHash()', ->
+		it 'should resolve with the correct hash', ->
+			m.chai.expect(
+				getFileHash('package.json')
+		).to.eventually.equal(savedBuildTriggers[0]['package.json'])
+
+	describe 'createBuildTriggerHashes()', ->
+		it 'should return file hashes', ->
+			createBuildTriggerHashes(files: _.keys(filesystem)).then (hashes) ->
+				m.chai.expect(hashes).to.deep.equal(savedBuildTriggers)
+
+		it "should return a single hash entry for 'Dockerfile', './Dockerfile' and '/full/path/Dockerfile'", ->
+			files = _.keys(filesystem)
+			files.push('./Dockerfile')
+			files.push(path.join(process.cwd(), 'Dockerfile'))
+
+			createBuildTriggerHashes({ files }).then (hashes) ->
+				m.chai.expect(hashes).to.deep.equal(savedBuildTriggers)
+
+		it 'should return file hashes if a file is missing and skipMissing is set to true (default)', ->
+			files = _.keys(filesystem)
+			files.push('test.json')
+
+			createBuildTriggerHashes({ files }).then (hashes) ->
+				m.chai.expect(hashes).to.deep.equal(savedBuildTriggers)
+
+		it 'should throw if file is missing and skipMissing is set to false', ->
+			files = _.keys(filesystem)
+			files.push('test.json')
+
+			m.chai.expect(
+				createBuildTriggerHashes({ files, skipMissing: false })
+			).to.be.rejectedWith('Could not calculate hash - File does not exist')
+
+	describe 'checkTriggers()', ->
+		it 'should resolve with true if a file is missing', ->
+			mockFs(_.omit(filesystem, 'Dockerfile'))
+
+			m.chai.expect(
+				checkTriggers(savedBuildTriggers)
+			).to.eventually.equal(true)
+
+		it 'should resolve with true if a file has changed', ->
+			mockFs(_.assign({}, filesystem, 'package.json': 'edited file'))
+
+			m.chai.expect(
+				checkTriggers(savedBuildTriggers)
+			).to.eventually.equal(true)
+
+		it 'should resolve with false if no file has changed', ->
+			m.chai.expect(
+				checkTriggers(savedBuildTriggers)
+			).to.eventually.equal(false)

--- a/tests/config.spec.coffee
+++ b/tests/config.spec.coffee
@@ -1,7 +1,7 @@
 m = require('mochainon')
 path = require('path')
 mockFs = require('mock-fs')
-config = require('../lib/config')
+config = require('../lib/yaml-config')
 
 describe 'Config:', ->
 

--- a/tests/rsync.spec.coffee
+++ b/tests/rsync.spec.coffee
@@ -24,7 +24,7 @@ assertCommand = (command, options) ->
 	expected += ' --rsh=\"ssh -p 22 -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ControlMaster=no\"'
 	expected += ' --delete'
 
-	expected += " --rsync-path=\"\\$(which rsync) 1234 4567\""
+	expected += ' --rsync-path=\"\\$(which rsync) 1234 4567\"'
 
 	expected += ' --include=\"lib/include with space.txt\" --include=\"lib/include with space trail.txt \"'
 	expected += ' --exclude=npm-debug.log --exclude=node_modules/ --exclude=lib/* --exclude=#notacomment'
@@ -47,7 +47,7 @@ describe 'Rsync:', ->
 		destination: "/usr/src/app/a/b/` ' @ ! $test \" end"
 		port: 22
 		host: 'ssh.resindevice.io'
-		'rsync-path': '$(which rsync) 1234 4567'
+		rsyncPath: '$(which rsync) 1234 4567'
 
 	beforeEach ->
 		mockFs(filesystem)

--- a/tests/utils.spec.coffee
+++ b/tests/utils.spec.coffee
@@ -1,4 +1,5 @@
 m = require('mochainon')
+mockFs = require('mock-fs')
 utils = require('../lib/utils')
 
 describe 'Utils:', ->
@@ -47,3 +48,20 @@ describe 'Utils:', ->
 							required: true
 							message: 'Bar should be a string'
 			.to.throw('Foo should be a number')
+
+	describe 'fileExists()', ->
+		filesystem =
+			'package.json': 'package.json contents'
+			'Dockerfile': 'Dockerfile contents'
+
+		beforeEach ->
+			mockFs(filesystem)
+
+		afterEach ->
+			mockFs.restore()
+
+		it 'should return true if file exists', ->
+			m.chai.expect(utils.fileExists('package.json')).to.be.true
+
+		it 'should return false if file does not exist', ->
+			m.chai.expect(utils.fileExists('test.json')).to.be.false


### PR DESCRIPTION
- Simplified build trigger logic and added tests
- Added more sane .resin-sync.yml load/save logic
- Rename config.coffee to yaml-config.coffee, since config.coffee
  usually holds application-wide configuration settings
- Refactor docker-utils as a RdtDockerUtils class object
- Improve cli option and parameter handling
- DRY out resin-cli sync to use shared modules
- [Breaking change] create separate module for interactive forms and
  export it
