### PR TITLE
Export 'discover' utils

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -18,4 +18,5 @@ module.exports =
 	capitano: (cliTool) -> require('./capitano')(cliTool)
 	sync: (target) -> require('./sync')(target)
 	config: require('./yaml-config')
+	discover: require('./discover')
 	forms: require('./forms')


### PR DESCRIPTION
This slipped through during 'resin-sync' code reorganization/cleanup