### PR TITLE
added '/run/dbus:/host_run/dbus' to the default bind-mounts list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+* Add `'/run/dbus:/host_run/dbus'` as a default bind-mount
+
 # 6.1.2
 
 * rdt: fix documentation

--- a/lib/docker-utils.coffee
+++ b/lib/docker-utils.coffee
@@ -53,6 +53,7 @@ defaultVolumes = {
 	'/lib/modules': {}
 	'/lib/firmware': {}
 	'/host/run/dbus': {}
+	'/host/run_dbus': {}
 }
 
 defaultBinds = (dataPath) ->
@@ -62,6 +63,7 @@ defaultBinds = (dataPath) ->
 		data
 		'/lib/modules:/lib/modules'
 		'/lib/firmware:/lib/firmware'
+		'/run/dbus:/host_run/dbus'
 		'/run/dbus:/host/run/dbus'
 	]
 


### PR DESCRIPTION
@lekkas not sure if anything else needs to be done, but this I think should fix https://github.com/resin-os/resin-device-toolbox/issues/67