### PR TITLE
Revert "Merge pull request #107 from resin-io-modules/host-dbus-mount"

### DIFF
--- a/lib/docker-utils.coffee
+++ b/lib/docker-utils.coffee
@@ -53,7 +53,6 @@ defaultVolumes = {
 	'/lib/modules': {}
 	'/lib/firmware': {}
 	'/host/run/dbus': {}
-	'/host/run_dbus': {}
 }
 
 defaultBinds = (dataPath) ->
@@ -63,7 +62,6 @@ defaultBinds = (dataPath) ->
 		data
 		'/lib/modules:/lib/modules'
 		'/lib/firmware:/lib/firmware'
-		'/run/dbus:/host_run/dbus'
 		'/run/dbus:/host/run/dbus'
 	]
 


### PR DESCRIPTION
This reverts commit a8623bc9e076b779f4ddbf278a00d6bf9fd10922, reversing
changes made to 61ac12e9c6c01c74ed4e2bfdef3ef3cdcfba967e.