### PR TITLE
Use experimental `resin-discoverable-services` with support for multiple interfaces listening.

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "lodash": "^4.13.1",
     "resin-cli-form": "^1.4.1",
     "resin-cli-visuals": "^1.2.8",
-    "resin-discoverable-services": "^1.0.0",
+    "resin-discoverable-services": "git+https://github.com/resin-io-modules/resin-discoverable-services#find-on-all-interfaces",
     "resin-sdk": "^5.1.0",
     "resin-settings-client": "^3.5.0",
     "revalidator": "^0.3.1",


### PR DESCRIPTION
Should ensure that every valid IPv4 interface is used to scan for resinOS devices.

Closes #117 
