### PR TITLE
Permit resin sync to collaborators

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
+  - "7"
+  - "6"
   - "5"
   - "4"
-  - "0.12"
 notifications:
   email: false

--- a/build/sync/remote-resin-io-device.js
+++ b/build/sync/remote-resin-io-device.js
@@ -153,13 +153,7 @@ exports.sync = function(arg) {
     var RequiredDeviceObjectFields, ensureDeviceRequirements;
     RequiredDeviceObjectFields = ['uuid', 'os_version'];
     ensureDeviceRequirements = function(device) {
-      return resin.auth.getUserId().then(function(userId) {
-        if (userId !== device.user.__id) {
-          throw new Error('Resin sync is permitted to the device owner only. The device owner is the user who provisioned it.');
-        }
-      }).then(function() {
-        return ensureHostOSCompatibility(device.os_version, MIN_HOSTOS_RSYNC);
-      }).then(function() {
+      return ensureHostOSCompatibility(device.os_version, MIN_HOSTOS_RSYNC).then(function() {
         var missingKeys;
         missingKeys = _.difference(RequiredDeviceObjectFields, _.keys(device));
         if (missingKeys.length > 0) {

--- a/lib/sync/remote-resin-io-device.coffee
+++ b/lib/sync/remote-resin-io-device.coffee
@@ -142,13 +142,7 @@ exports.sync = ({ uuid, baseDir, destination, before, after, ignore, port = 22, 
 
 		# Returns a promise that is resolved with the API-fetched device object or rejected on error or missing requirement
 		ensureDeviceRequirements = (device) ->
-			# Ensure user is the owner of the device. This is also checked on the backend side.
-			resin.auth.getUserId()
-			.then (userId) ->
-				if userId isnt device.user.__id
-					throw new Error('Resin sync is permitted to the device owner only. The device owner is the user who provisioned it.')
-			.then -> # Ensure minimum required HostOS version for resin sync
-				ensureHostOSCompatibility(device.os_version, MIN_HOSTOS_RSYNC)
+			ensureHostOSCompatibility(device.os_version, MIN_HOSTOS_RSYNC)
 			.then ->
 				missingKeys = _.difference(RequiredDeviceObjectFields, _.keys(device))
 				if missingKeys.length > 0


### PR DESCRIPTION
change-type: major
fixes #36 

Tested with the latest resin-proxy changes on staging. This can be published now and a major version bump to `resin-cli` will follow *after* the latest resin-proxy changes have been deployed to master.