### PR TITLE
Fix arguments to shell.runCommand

### DIFF
--- a/build/sync/local-resin-os-device.js
+++ b/build/sync/local-resin-os-device.js
@@ -98,9 +98,7 @@ exports.sync = function(arg) {
           throw new Error("Container must be running before attempting 'sync' action");
         }
         return new SpinnerPromise({
-          promise: shell.runCommand(command, {
-            cwd: baseDir
-          }),
+          promise: shell.runCommand(command, baseDir),
           startMessage: "Syncing to " + destination + " on '" + appName + "'...",
           stopMessage: "Synced " + destination + " on '" + appName + "'."
         });


### PR DESCRIPTION
I have been encountering the following error while trying to push to a local device:

```js
rdt push failed. TypeError: "cwd" must be a string TypeError: "cwd" must be a string
    at normalizeSpawnArguments (child_process.js:380:11)
    at Object.exports.spawn (child_process.js:465:38)
    at Object.<anonymous> (/usr/local/lib/node_modules/resin-cli/node_modules/resin-sync/build/shell.js:84:25)
    at Object.tryCatcher (/usr/local/lib/node_modules/resin-cli/node_modules/bluebird/js/release/util.js:16:23)
    at Object.runCommand (/usr/local/lib/node_modules/resin-cli/node_modules/bluebird/js/release/method.js:15:34)
    at /usr/local/lib/node_modules/resin-cli/node_modules/resin-sync/build/sync/local-resin-os-device.js:101:26
    at tryCatcher (/usr/local/lib/node_modules/resin-cli/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/usr/local/lib/node_modules/resin-cli/node_modules/bluebird/js/release/promise.js:512:31)
    at Promise._settlePromise (/usr/local/lib/node_modules/resin-cli/node_modules/bluebird/js/release/promise.js:569:18)
    at Promise._settlePromise0 (/usr/local/lib/node_modules/resin-cli/node_modules/bluebird/js/release/promise.js:614:10)
    at Promise._settlePromises (/usr/local/lib/node_modules/resin-cli/node_modules/bluebird/js/release/promise.js:693:18)
    at Promise._fulfill (/usr/local/lib/node_modules/resin-cli/node_modules/bluebird/js/release/promise.js:638:18)
    at Promise._settlePromise (/usr/local/lib/node_modules/resin-cli/node_modules/bluebird/js/release/promise.js:582:21)
    at Promise._settlePromise0 (/usr/local/lib/node_modules/resin-cli/node_modules/bluebird/js/release/promise.js:614:10)
    at Promise._settlePromises (/usr/local/lib/node_modules/resin-cli/node_modules/bluebird/js/release/promise.js:693:18)
    at Promise._fulfill (/usr/local/lib/node_modules/resin-cli/node_modules/bluebird/js/release/promise.js:638:18)
    at Promise._resolveCallback (/usr/local/lib/node_modules/resin-cli/node_modules/bluebird/js/release/promise.js:432:57)
    at Promise._settlePromiseFromHandler (/usr/local/lib/node_modules/resin-cli/node_modules/bluebird/js/release/promise.js:524:17)
    at Promise._settlePromise (/usr/local/lib/node_modules/resin-cli/node_modules/bluebird/js/release/promise.js:569:18)
    at Promise._settlePromise0 (/usr/local/lib/node_modules/resin-cli/node_modules/bluebird/js/release/promise.js:614:10)
    at Promise._settlePromises (/usr/local/lib/node_modules/resin-cli/node_modules/bluebird/js/release/promise.js:693:18)
    at Promise._fulfill (/usr/local/lib/node_modules/resin-cli/node_modules/bluebird/js/release/promise.js:638:18)
    at Object.callback (/usr/local/lib/node_modules/resin-cli/node_modules/bluebird/js/release/nodeback.js:42:21)
    at /usr/local/lib/node_modules/resin-cli/node_modules/dockerode/lib/container.js:72:12
    at Modem.buildPayload (/usr/local/lib/node_modules/resin-cli/node_modules/docker-modem/lib/modem.js:259:7)
    at IncomingMessage.<anonymous> (/usr/local/lib/node_modules/resin-cli/node_modules/docker-modem/lib/modem.js:218:14)
    at emitNone (events.js:110:20)
    at IncomingMessage.emit (events.js:207:7)
    at endReadableNT (_stream_readable.js:1045:12)
    at _combinedTickCallback (internal/process/next_tick.js:102:11)
    at process._tickDomainCallback (internal/process/next_tick.js:198:9)
```

From examining shell.js and local-resin-os-device.js, I believe the error is occurring because the second argument to shell.runCommand should be a string, not an object. See [here](https://github.com/resin-io-modules/resin-sync/blob/master/build/shell.js#L75).