### PR TITLE
Fix "'cwd' must be a string" error in Node 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+* Fix "'cwd' must be a string" error in Node 8
+
 # 8.0.0
 
 * Do not explicitly disable ControlMaster SSH option

--- a/build/sync/local-resin-os-device.js
+++ b/build/sync/local-resin-os-device.js
@@ -98,9 +98,7 @@ exports.sync = function(arg) {
           throw new Error("Container must be running before attempting 'sync' action");
         }
         return new SpinnerPromise({
-          promise: shell.runCommand(command, {
-            cwd: baseDir
-          }),
+          promise: shell.runCommand(command, baseDir),
           startMessage: "Syncing to " + destination + " on '" + appName + "'...",
           stopMessage: "Synced " + destination + " on '" + appName + "'."
         });

--- a/build/sync/remote-resin-io-device.js
+++ b/build/sync/remote-resin-io-device.js
@@ -196,9 +196,7 @@ exports.sync = function(arg) {
     };
     command = buildRsyncCommand(syncOptions);
     return new SpinnerPromise({
-      promise: shell.runCommand(command, {
-        cwd: baseDir
-      }),
+      promise: shell.runCommand(command, baseDir),
       startMessage: "Syncing to " + destination + " on " + (fullUuid.substring(0, 7)) + "...",
       stopMessage: "Synced " + destination + " on " + (fullUuid.substring(0, 7)) + "."
     });

--- a/lib/sync/local-resin-os-device.coffee
+++ b/lib/sync/local-resin-os-device.coffee
@@ -86,7 +86,7 @@ exports.sync = ({ deviceIp, baseDir, appName, destination, before, after, progre
 					throw new Error("Container must be running before attempting 'sync' action")
 
 				new SpinnerPromise
-					promise: shell.runCommand(command, cwd: baseDir)
+					promise: shell.runCommand(command, baseDir)
 					startMessage: "Syncing to #{destination} on '#{appName}'..."
 					stopMessage: "Synced #{destination} on '#{appName}'."
 

--- a/lib/sync/remote-resin-io-device.coffee
+++ b/lib/sync/remote-resin-io-device.coffee
@@ -180,7 +180,7 @@ exports.sync = ({ uuid, baseDir, destination, before, after, ignore, port = 22, 
 		command = buildRsyncCommand(syncOptions)
 
 		new SpinnerPromise
-			promise: shell.runCommand(command, cwd: baseDir)
+			promise: shell.runCommand(command, baseDir)
 			startMessage: "Syncing to #{destination} on #{fullUuid.substring(0, 7)}..."
 			stopMessage: "Synced #{destination} on #{fullUuid.substring(0, 7)}."
 


### PR DESCRIPTION
Connects to https://github.com/resin-io/resin-cli/issues/543.

`shell.runCommand` actually just expects a string: it builds the `{ cwd: cwd }` options object itself. We've presumably been doing this wrong since forever (essentially providing `{ cwd: { cwd: cwd } }` as our options), but in Node 8 `child_process.spawn` has started validating its arguments and throwing exceptions in cases like this, breaking the CLI.