### PR TITLE
Make Docker version comparison accept Docker's new non-semver versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 # Unreleased
 
+* Make Docker version comparison accept Docker's new non-semver versioning (e.g 17.03.0)
 * Add support for overlay2 in local push
 
 # 9.0.0

--- a/build/docker-utils.js
+++ b/build/docker-utils.js
@@ -406,7 +406,7 @@ RdtDockerUtils = (function() {
       containerId = containerInfo.Id;
       return Promise["try"](function() {
         var destFile, readFile;
-        if (semver.lt(dockerVersion, '1.10.0')) {
+        if (semver.lt(dockerVersion, '1.10.0', true)) {
           return containerId;
         }
         destFile = path.join(dkroot, "image/" + dockerInfo.Driver + "/layerdb/mounts", containerId, 'mount-id');

--- a/lib/docker-utils.coffee
+++ b/lib/docker-utils.coffee
@@ -302,7 +302,7 @@ class RdtDockerUtils
 			containerId = containerInfo.Id
 
 			Promise.try ->
-				if semver.lt(dockerVersion, '1.10.0')
+				if semver.lt(dockerVersion, '1.10.0', true)
 					return containerId
 
 				destFile = path.join(dkroot, "image/#{dockerInfo.Driver}/layerdb/mounts", containerId, 'mount-id')


### PR DESCRIPTION
Not confirmed, but I'm hoping this will resolve https://github.com/resin-io/resin-cli/issues/608.

This is the same behaviour as in docker-toolbelt, which does seem to handle new Docker versions ok: https://github.com/resin-io-modules/docker-toolbelt/blob/873d9573fae5e6c98ef807dc1671610e87a85d2b/lib/docker-toolbelt.coffee#L81 (independently, we should really look at refactoring this to share that implementation, I'll take a look at that shortly)