### PR TITLE
Add support for overlay2 in local push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+# Unreleased
+
+* Add support for overlay2 in local push
+
 # 9.0.0
 
 * **Breaking!** Drop support for node < 6

--- a/build/docker-utils.js
+++ b/build/docker-utils.js
@@ -422,6 +422,8 @@ RdtDockerUtils = (function() {
             return path.join(dkroot, 'btrfs/subvolumes', destId);
           case 'overlay':
             return containerInfo.GraphDriver.Data.RootDir;
+          case 'overlay2':
+            return containerInfo.GraphDriver.Data.MergedDir;
           case 'vfs':
             return path.join(dkroot, 'vfs/dir', destId);
           case 'aufs':

--- a/lib/docker-utils.coffee
+++ b/lib/docker-utils.coffee
@@ -320,6 +320,8 @@ class RdtDockerUtils
 						path.join(dkroot, 'btrfs/subvolumes', destId)
 					when 'overlay'
 						containerInfo.GraphDriver.Data.RootDir
+					when 'overlay2'
+						containerInfo.GraphDriver.Data.MergedDir
 					when 'vfs'
 						path.join(dkroot, 'vfs/dir', destId)
 					when 'aufs'


### PR DESCRIPTION
This should solve https://github.com/resin-io/resin-cli/issues/599.

I don't have an overlay2 device to test with (and I'm not sure how to set up one up), but I've done some basic testing against my local docker instance, using overlay2, and it seems to be working correctly.