### PR TITLE
Update resin-semver to support balenaOS version strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "resin-cli-visuals": "^1.2.8",
     "resin-discoverable-services": "git+https://github.com/resin-io-modules/resin-discoverable-services#find-on-all-interfaces",
     "resin-sdk": "9.0.0-beta24",
-    "resin-semver": "^1.3.0",
+    "resin-semver": "^1.4.0",
     "resin-settings-client": "^3.5.0",
     "revalidator": "^0.3.1",
     "rindle": "^1.3.0",


### PR DESCRIPTION
This repo is one of 16 repos identified to use/require a [resin-semver](https://github.com/resin-io-modules/resin-semver) version older than 1.4.0. See also:
* [Trello card](https://trello.com/c/11ZJfEv6/114-update-repos-that-depend-on-resin-semver)
* [Flowdock thread](https://www.flowdock.com/app/rulemotion/namechange/threads/lS-o4xF4qMvf-o2rAtdrqaZEPhs)